### PR TITLE
正しいワークフロー名に修正（CI → PR Push check）

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -2,7 +2,7 @@ name: Merge Master
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["PR Push check"]
     types: [completed]
   pull_request:
     types: [auto_merge_enabled]


### PR DESCRIPTION
## Summary
- merge-masterワークフローのトリガー対象を正しいワークフロー名に修正
- `workflows: ["CI"]` → `workflows: ["PR Push check"]`

## Test plan
- [ ] ワークフロー設定が正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)