### PR TITLE
feat: Webアプリに共有コンポーネントパッケージを統合

### DIFF
--- a/apps/web/app/app.css
+++ b/apps/web/app/app.css
@@ -1,15 +1,2 @@
-@import "tailwindcss" source(".");
-
-@theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-}
-
-html,
-body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
-}
+@import "@packages/react-components/globals.css";
+@source "../../../packages/react-components"

--- a/apps/web/app/welcome/welcome.tsx
+++ b/apps/web/app/welcome/welcome.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@packages/react-components";
 import logoDark from "./logo-dark.svg";
 import logoLight from "./logo-light.svg";
 
@@ -39,6 +40,9 @@ export function Welcome({ message }: { message: string }) {
 								</li>
 							))}
 							<li className="self-stretch p-3 leading-normal">{message}</li>
+							<li>
+								<Button>Get Started</Button>
+							</li>
 						</ul>
 					</nav>
 				</div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,11 +19,12 @@
 		"react-router": "7.5.3"
 	},
 	"devDependencies": {
-		"@configs/common": "workspace:*",
-		"@configs/react": "workspace:*",
-		"@configs/node": "workspace:*",
 		"@biomejs/biome": "2.0.6",
 		"@cloudflare/vite-plugin": "1.0.12",
+		"@configs/common": "workspace:*",
+		"@configs/node": "workspace:*",
+		"@configs/react": "workspace:*",
+		"@packages/react-components": "workspace:*",
 		"@react-router/dev": "7.5.3",
 		"@tailwindcss/vite": "4.1.4",
 		"@types/node": "20",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -8,8 +8,6 @@
 		"./globals.css": "./src/globals.css"
 	},
 	"scripts": {
-		"dev": "vite",
-		"build": "tsc -b && vite build",
 		"lint": "biome check .",
 		"preview": "vite preview",
 		"storybook": "storybook dev -p 6006",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@configs/react':
         specifier: workspace:*
         version: link:../../configs/react
+      '@packages/react-components':
+        specifier: workspace:*
+        version: link:../../packages/react-components
       '@react-router/dev':
         specifier: 7.5.3
         version: 7.5.3(@types/node@20.19.9)(jiti@2.4.2)(lightningcss@1.30.1)(react-router@7.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)(vite@6.3.3(@types/node@20.19.9)(jiti@2.4.2)(lightningcss@1.30.1))(wrangler@4.24.3)


### PR DESCRIPTION
## 概要

Webアプリケーションに共有コンポーネントパッケージ（@packages/react-components）を統合し、実際にButtonコンポーネントを使用できるようにしました。

## この変更による影響

- Webアプリケーションで共有コンポーネントライブラリを使用できるようになります
- デザインシステムの一貫性が保たれ、コンポーネントの再利用性が向上します
- 今後、新しいコンポーネントを追加する際の基盤が整いました

## CIでチェックできなかった項目

- Buttonコンポーネントの表示と動作の確認（ブラウザでの目視確認が必要）

## 補足

- app.cssで共有コンポーネントのグローバルCSSをインポートしています
- WelcomeコンポーネントにGet Startedボタンを追加しました
- react-componentsパッケージから不要なビルドスクリプトを削除しました

🤖 Generated with [Claude Code](https://claude.ai/code)