### PR TITLE
feat(auth-database): テスト用のcreateDatabase関数をexport

### DIFF
--- a/packages/auth-database/README.md
+++ b/packages/auth-database/README.md
@@ -4,13 +4,40 @@ Next Liftの認証用データベースパッケージ。Better AuthとDrizzle O
 
 ## 概要
 
-このパッケージは、Better Authインスタンス（`auth`）を提供します。認証エンドポイントの作成やユーザー管理に使用します。
+このパッケージは、以下を提供します：
+
+### `auth`
+
+Better Authインスタンス。認証エンドポイントの作成やユーザー管理に使用します。
 
 ```typescript
 import { auth } from "@next-lift/auth-database";
 ```
 
-内部的には、Drizzle ORMによるデータベーススキーマ管理と、環境に応じたデータベース接続（リモート/ローカルファイル/インメモリ）を行っています。
+環境変数の設定に応じて、リモートデータベース（本番環境）またはローカルファイル（開発環境）に接続します。
+
+### `createDatabase`
+
+データベースクライアントを作成する関数。以下の3種類の接続タイプに対応しています：
+
+```typescript
+import { createDatabase } from "@next-lift/auth-database";
+
+// リモート接続（Turso）
+const remoteDb = createDatabase({
+  type: "remote",
+  url: "libsql://...",
+  authToken: "...",
+});
+
+// ローカルファイル
+const fileDb = createDatabase({ type: "file" });
+
+// インメモリ（テスト用途など）
+const memoryDb = createDatabase({ type: "memory" });
+```
+
+主にテスト環境で使用することを想定しています。詳細は [TESTING.md](./TESTING.md) を参照してください。
 
 ## データベース構成
 

--- a/packages/auth-database/TESTING.md
+++ b/packages/auth-database/TESTING.md
@@ -1,0 +1,157 @@
+# Testing Guide
+
+このドキュメントでは、`@next-lift/auth-database` を使用したアプリケーション（`apps/web`、`apps/ios`）でテストを書く際のベストプラクティスを説明します。
+
+## テスト戦略
+
+### 基本方針
+
+- **認証機能のテストは統合テストとして実施する**
+  - Better Auth APIを通してのみデータ操作を行う
+  - データベースの実装詳細には依存しない
+- **インメモリデータベースを使用する**
+  - テストの高速化
+  - テスト間の分離を保証
+  - 外部サービスへの依存を排除
+
+### auth-databaseパッケージの責務
+
+このパッケージは以下を提供します：
+
+- `auth`: 本番環境用のBetter Authインスタンス
+- `createDatabase`: テスト用インメモリデータベース作成関数
+
+データベーススキーマや直接的なDB操作関数はexportしません。すべての操作は `auth` インスタンスを通して行います。
+
+## テストの書き方
+
+### 推奨: @better-auth-kit/tests を使用
+
+`@better-auth-kit/tests` は、Better Auth公式のテストユーティリティパッケージです。テスト用インスタンスの作成やテストユーザーの管理を簡単に行えます。
+
+#### 1. 必要なパッケージのインストール
+
+```bash
+pnpm add -D @better-auth-kit/tests vitest
+```
+
+#### 2. テストヘルパーの作成
+
+```typescript
+// test/auth.test-setup.ts
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { getTestInstance } from "@better-auth-kit/tests";
+import { createDatabase } from "@next-lift/auth-database";
+
+export async function createAuthTestContext() {
+  // インメモリデータベースを作成
+  const db = createDatabase({ type: "memory" });
+
+  // テスト用Better Authインスタンスを作成
+  const auth = betterAuth({
+    database: drizzleAdapter(db, {
+      provider: "sqlite",
+    }),
+    secret: "test-secret",
+    emailAndPassword: { enabled: true },
+    // テスト用の設定
+    rateLimit: { enabled: false },
+    advanced: { disableCSRFCheck: true },
+  });
+
+  // @better-auth-kit/testsでラップ
+  return await getTestInstance(auth);
+}
+```
+
+#### 3. テストの実装
+
+```typescript
+// test/auth.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createAuthTestContext } from "./auth.test-setup";
+
+describe("認証フロー", () => {
+  let ctx: Awaited<ReturnType<typeof createAuthTestContext>>;
+
+  beforeEach(async () => {
+    // 各テストで新しいコンテキストを作成（テスト間の分離）
+    ctx = await createAuthTestContext();
+  });
+
+  it("デフォルトのテストユーザーでログインできる", async () => {
+    const { user } = await ctx.signInWithTestUser();
+    expect(user.email).toBe("test@example.com");
+  });
+
+  it("新しいユーザーを登録できる", async () => {
+    const result = await ctx.client.signUp.email({
+      email: "newuser@example.com",
+      password: "password123",
+      name: "New User",
+    });
+
+    expect(result.data?.user.email).toBe("newuser@example.com");
+  });
+});
+```
+
+### 代替案: Better Authを直接使用
+
+`@better-auth-kit/tests` を使わない場合でも、インメモリデータベースを使ってテストできます。
+
+```typescript
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { createDatabase } from "@next-lift/auth-database";
+
+// テスト用authインスタンスを作成
+const testDb = createDatabase({ type: "memory" });
+const testAuth = betterAuth({
+  database: drizzleAdapter(testDb, { provider: "sqlite" }),
+  secret: "test-secret",
+  // その他の設定...
+});
+
+// testAuthを使ってテストを実施
+```
+
+## 重要なポイント
+
+### 1. テスト間の分離
+
+各テストで新しいインメモリデータベースを作成することで、テスト間の状態汚染を防ぎます。
+
+```typescript
+beforeEach(async () => {
+  // 毎回新しいコンテキストを作成
+  ctx = await createAuthTestContext();
+});
+```
+
+### 2. Better Auth APIを使用
+
+データベースを直接操作せず、必ずBetter AuthのAPIを通してデータ操作を行います。
+
+```typescript
+// ❌ 悪い例: データベースを直接操作
+await db.insert(userTable).values({ ... });
+
+// ✅ 良い例: Better Auth APIを使用
+await ctx.client.signUp.email({ ... });
+```
+
+### 3. テスト用設定の有効化
+
+テストでは以下の設定を推奨します：
+
+- `rateLimit: { enabled: false }`: レート制限を無効化
+- `advanced: { disableCSRFCheck: true }`: CSRF チェックを無効化
+
+## 参考資料
+
+- [Better Auth公式ドキュメント](https://www.better-auth.com/docs)
+- [@better-auth-kit/tests](https://www.better-auth-kit.com/docs/libraries/tests)
+- [Drizzle ORM](https://orm.drizzle.team/)
+- [libSQL Client](https://docs.turso.tech/sdk/ts/reference)

--- a/packages/auth-database/src/index.ts
+++ b/packages/auth-database/src/index.ts
@@ -1,1 +1,2 @@
 export { auth } from "./auth";
+export { createDatabase } from "./client";


### PR DESCRIPTION
# 概要

auth-databaseパッケージに`createDatabase`関数のexportとテストガイドを追加しました。これにより、apps/webやapps/iosでBetter Authの認証機能をテストする際に、統一されたアプローチでインメモリデータベースを使ったテスト環境をセットアップできるようになります。

## この変更による影響

**パッケージを利用するアプリケーションへの影響:**
- apps/webやapps/iosで認証機能のテストを書く際、`createDatabase({ type: "memory" })`を使ってインメモリデータベースを作成できる
- TESTING.mdを参照することで、推奨されるテストの書き方（@better-auth-kit/testsの使用）が分かる
- すべてのデータ操作をBetter Auth APIを通して行うことで、実装の詳細に依存しないテストが書ける

**既存コードへの影響:**
- 破壊的変更なし（新規exportの追加のみ）

## CIでチェックできなかった項目

- TESTING.mdに記載されたテスト方法が実際に動作するかの確認
  - apps/webまたはapps/iosで実際にテストを書く際に検証する必要がある
- `createDatabase`のexportが適切に機能するかの確認
  - 型チェックは通るが、実際の利用シーンでの動作確認は未実施

## 補足

**技術的な背景:**
- Better Auth、Drizzle ORM、libSQLの公式ドキュメントを調査し、推奨されるテスト方法を確認済み
- `@better-auth-kit/tests`を使ったテストアプローチを推奨している
- データベーススキーマ（schema）は意図的にexportしていない（Better Auth APIを通した操作に限定するため）

**関連タスク:**
- docs/project/001-infra.md の「テスト用データベースのセットアップ」に該当

🤖 Generated with [Claude Code](https://claude.com/claude-code)