### PR TITLE
Biome設定の一貫性を改善

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,18 +1,14 @@
 {
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	"vcs": {
-		"enabled": false,
+		"enabled": true,
 		"clientKind": "git",
-		"useIgnoreFile": false
+		"useIgnoreFile": true,
+		"defaultBranch": "main"
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": [
-			"**",
-			"!**/dist/**",
-			"!**/build/**",
-			"!**/node_modules/**"
-		]
+		"includes": ["**", "!**/dist/**", "!**/build/**", "!**/node_modules/**"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/packages/authentication/biome.jsonc
+++ b/packages/authentication/biome.jsonc
@@ -1,0 +1,5 @@
+{
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+	"root": false,
+	"extends": "//"
+}


### PR DESCRIPTION
# 概要

モノレポ全体でBiome設定の継承を統一するため、Biome v2のモノレポ機能(`extends: "//"`)を活用する設定を追加しました。

## この変更による影響

### 開発者への影響
- `packages/authentication`でもルートのBiome設定が自動的に継承されるようになります
- 今後パッケージを追加する際は、同様に`biome.jsonc`で`extends: "//"`を指定することで統一された設定を使用できます

### VCS機能の有効化
- ルートの`biome.jsonc`でVCS機能を有効化したため、Git管理されているファイルのみがチェック対象になります
- `.gitignore`で除外されているファイルは自動的にチェックから除外されます

## CIでチェックできなかった項目

- `packages/authentication`で実際にルート設定が継承されているかの動作確認
  - ✅ `pnpm --filter=@next-lift/authentication lint`で正常動作を確認済み

## 補足

この変更により、以下のような統一された設定管理が可能になります：
- ルートで共通ルールを定義
- 各パッケージで`extends: "//"`により継承
- 必要に応じてパッケージごとにルールを上書き可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)