### PR TITLE
noPrivateImportsルールを無効化

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -26,12 +26,6 @@
 				"useWhile": "warn"
 			},
 			"correctness": {
-				"noPrivateImports": {
-					"level": "warn",
-					"options": {
-						"defaultVisibility": "package"
-					}
-				},
 				"noRenderReturnValue": "warn",
 				"noUndeclaredDependencies": "warn",
 				"useHookAtTopLevel": "warn",


### PR DESCRIPTION
# 概要

Biomeの`noPrivateImports`ルールを無効化しました。

Rustライクなモジュール可視性制御を試みましたが、JavaScriptエコシステムでは一般的ではないため、シンプルさを優先して無効化します。

## この変更による影響

### 開発者への影響
- `noPrivateImports`警告が表示されなくなる
- monorepo内でのコンポーネント共有時の警告が解消される
- よりシンプルで一般的なJavaScript/TypeScriptの慣習に従う

### ユーザーへの影響
- なし（開発環境の変更のみ）

## 無効化の理由

1. **JavaScriptコミュニティで一般的ではない**
   - Rustのようなモジュール可視性制御は、JavaScriptでは広く採用されていない
   - チーム開発でも理解されにくく、ドキュメントも少ない

2. **exportの存在が十分な意図表現**
   - TypeScriptの型システムとexportパターンで公開APIを明示できる
   - 必要に応じてJSDocの`@internal`コメントも使用可能

3. **monorepoでの課題**
   - パッケージ間でのコンポーネント共有時に警告が多発
   - Intent UI統合時にも警告が発生

4. **シンプルさの優先**
   - 個人開発では、よりシンプルな方針が望ましい
   - パッケージ境界の設計で十分に対応可能

## 代替手段

- TypeScriptの型システムとexportパターン
- JSDocの`@internal`コメント（必要な場合）
- パッケージ境界の明確な設計

## CIでチェックできなかった項目

- [x] ローカルでlintを実行し、警告が消えたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)