### PR TITLE
refactor: apps/webのTypeScript設定を強化

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,7 +26,9 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.1.4",
 		"@tailwindcss/postcss": "4.1.16",
+		"@tsconfig/create-react-app": "2.0.8",
 		"@tsconfig/next": "2.0.3",
+		"@tsconfig/strictest": "2.0.6",
 		"@types/node": "24.9.1",
 		"@types/react": "19.2.2",
 		"@types/react-dom": "19.2.2",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,14 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
-	"extends": "@tsconfig/next/tsconfig.json",
+	"extends": [
+		"@tsconfig/strictest/tsconfig.json",
+		"@tsconfig/create-react-app/tsconfig.json",
+		"@tsconfig/next/tsconfig.json"
+	],
 	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"noEmit": true,
 		"target": "ES2017"
 	},
 	"include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: 4.1.16
         version: 4.1.16
+      '@tsconfig/create-react-app':
+        specifier: 2.0.8
+        version: 2.0.8
       '@tsconfig/next':
         specifier: 2.0.3
         version: 2.0.3
+      '@tsconfig/strictest':
+        specifier: 2.0.6
+        version: 2.0.6
       '@types/node':
         specifier: 24.9.1
         version: 24.9.1


### PR DESCRIPTION
# 概要

apps/webのTypeScript設定をより厳格にするため、@tsconfig/strictestと@tsconfig/create-react-appを追加しました。

これにより、より多くの潜在的なバグを型チェック時に検出できるようになり、コードの品質が向上します。

**前提**: このPRは #274 (`feature/create-react-components-package`) に依存しています。#274がマージされた後、このPRのベースブランチをmainに変更してください。

## この変更による影響

### アプリケーション開発者への影響

- より厳格な型チェックが有効化されます
- 潜在的な型エラーが早期に検出されるようになります
- コードの型安全性が向上します

### 設定変更の詳細

- **@tsconfig/strictest**: 最も厳格な型チェックルールセット
- **@tsconfig/create-react-app**: React向けの推奨設定
- **module/moduleResolution**: ESNext/Bundler（モダンな設定）
- **noEmit**: true（型チェックのみ実行、ビルドはNext.jsに任せる）

## CIでチェックできなかった項目

### 動作確認が必要

- [ ] apps/webの型チェックが正常に完了すること (`pnpm type-check`)
- [ ] apps/webのビルドが成功すること (`pnpm build`)
- [ ] 既存の機能が正常に動作すること

### 手動確認済み

- [x] ローカル環境で型チェックエラーなし
- [x] apps/webの開発サーバーが正常に起動

## 補足

この変更は、packages/react-componentsパッケージの作成作業中に実施したTypeScript設定の改善を、別ブランチとして分離したものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)