### PR TITLE
refactor: ButtonコンポーネントをReact 19の新仕様に対応

### DIFF
--- a/packages/react-components/src/ui/button.tsx
+++ b/packages/react-components/src/ui/button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { FC } from "react";
 import {
 	Button as ButtonPrimitive,
 	type ButtonProps as ButtonPrimitiveProps,
@@ -88,23 +89,17 @@ export const buttonStyles = tv({
 	},
 });
 
-export interface ButtonProps
-	extends ButtonPrimitiveProps,
-		VariantProps<typeof buttonStyles> {
-	ref?: React.Ref<HTMLButtonElement>;
-}
+type Props = ButtonPrimitiveProps & VariantProps<typeof buttonStyles>;
 
-export function Button({
+export const Button: FC<Props> = ({
 	className,
 	intent,
 	size,
 	isCircle,
-	ref,
 	...props
-}: ButtonProps) {
+}) => {
 	return (
 		<ButtonPrimitive
-			ref={ref}
 			{...props}
 			className={cx(
 				buttonStyles({
@@ -116,4 +111,4 @@ export function Button({
 			)}
 		/>
 	);
-}
+};


### PR DESCRIPTION
# 概要

React 19ではforwardRefが不要になり、refを通常のpropsとして扱えるようになったため、ButtonコンポーネントをReact 19の新しい仕様に準拠するようリファクタリングしました。

**前提**: このPRは #275 (`refactor/strengthen-web-typescript-config`) に依存しています。

## この変更による影響

### 開発者への影響

- コンポーネントの実装がよりシンプルになります
- React 19の新しいref仕様に準拠したコードになります
- 今後のコンポーネント実装のリファレンスとして利用できます

### 変更の詳細

**Before:**
```typescript
export interface ButtonProps extends ButtonPrimitiveProps, VariantProps<typeof buttonStyles> {
  ref?: React.Ref<HTMLButtonElement>;
}

export function Button({ className, intent, size, isCircle, ref, ...props }: ButtonProps) {
  return <ButtonPrimitive ref={ref} {...props} />;
}
```

**After:**
```typescript
type Props = ButtonPrimitiveProps & VariantProps<typeof buttonStyles>;

export const Button: FC<Props> = ({ className, intent, size, isCircle, ...props }) => {
  return <ButtonPrimitive {...props} />;
};
```

**主な変更点:**
- Props型: `interface` → `type`
- Props型をexportしない（内部型に変更）
- Props型名: `ButtonProps` → `Props`
- `ref?: React.Ref<HTMLButtonElement>`を削除
- 関数宣言からアロー関数+FC型注釈に変更
- refパラメータと明示的なref渡しを削除

## CIでチェックできなかった項目

### 動作確認が必要

- [ ] apps/webの `/test-intent` ページでボタンが正常に動作すること
- [ ] Storybookでボタンコンポーネントが表示されること

### 手動確認済み

- [x] 型チェックエラーなし（packages/react-components, apps/web）
- [x] ローカル環境でapps/webが正常に動作

## 補足

### React 19のref仕様について

React 19では、FCコンポーネントに自動的にrefが含まれます。そのため：
- Props型にrefを含める必要がない
- `{...props}`でネストされたコンポーネントに自動的に渡される
- forwardRefが不要

詳細: https://react.dev/blog/2024/12/05/react-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)