### PR TITLE
docs: packages/react-componentsのコンポーネント実装規約とLinter設定を追加

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -57,7 +57,6 @@
 				"useIndexOf": "warn",
 				"useIterableCallbackReturn": "warn",
 				"useObjectSpread": "warn",
-				"useSortedClasses": "warn",
 				"useUniqueElementIds": "warn"
 			}
 		}

--- a/packages/react-components/CLAUDE.md
+++ b/packages/react-components/CLAUDE.md
@@ -1,0 +1,47 @@
+# packages/react-components
+
+このパッケージは、Next LiftのWebアプリケーション（apps/web）で使用するReactコンポーネントライブラリです。
+
+**注意**: このパッケージはReact DOM向けです。React Native（iOS）向けのコンポーネントは`packages/react-native-components`で管理します。
+
+## コンポーネント実装規約
+
+### コンポーネントの書き方
+
+すべてのReactコンポーネントは以下の形式で実装してください：
+
+```typescript
+import type { FC } from "react";
+
+type Props = {
+  // props定義
+  // React 19では ref は自動的に Props に含まれるため、明示的に定義する必要なし
+};
+
+export const ComponentName: FC<Props> = ({ ...props }) => {
+  // 実装
+};
+```
+
+**重要なポイント:**
+
+1. **型定義**
+   - `import type { FC }` でFCをimport（Tree-shakingのため）
+   - Props型は`export`しない（外部に公開しない）
+   - Props型名は`Props`（シンプルな名前）
+   - `type`を使用（`interface`ではなく）
+
+2. **関数定義**
+   - アロー関数 + FC型注釈を使用
+   - `export function`ではなく`export const`
+
+3. **ref の扱い（React 19）**
+   - React 19では`forwardRef`が不要
+   - `ref`は自動的にpropsの一部として扱われる
+   - Props型に`ref?: React.Ref<...>`を含める必要なし
+   - コンポーネント内で`ref`を明示的に取り出す必要なし
+   - `{...props}`でネストされたコンポーネントに自動的に渡される
+
+### 参考実装
+
+- [src/ui/button.tsx](src/ui/button.tsx): React 19のref仕様に準拠した実装例

--- a/packages/react-components/biome.jsonc
+++ b/packages/react-components/biome.jsonc
@@ -1,5 +1,17 @@
 {
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	"root": false,
-	"extends": "//"
+	"extends": "//",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useSortedClasses": {
+					"level": "warn",
+					"options": {
+						"functions": ["tv", "cx", "cn"]
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
# 概要

packages/react-componentsパッケージでの統一的なコンポーネント実装を促進するため、実装規約を文書化し、Tailwind CSSクラスの自動ソートを設定しました。

**前提**: このPRは #277 (`refactor/button-component-react19`) に依存しています。

## この変更による影響

### 開発者への影響

- コンポーネント実装時の明確なガイドラインが提供されます
- React 19のref仕様に準拠した実装方法が文書化されます
- Tailwind CSSクラスが自動的にソートされ、コードの一貫性が向上します

### 追加した内容

#### 1. packages/react-components/CLAUDE.md

コンポーネント実装規約を文書化：
- React 19のref仕様に準拠した実装方法
- FC型注釈の使用方法（`import type { FC }`）
- Props型の命名規則（`type Props`、exportしない）
- button.tsxを参考実装として明記

#### 2. Biome Linter設定

Tailwind CSSクラスの自動ソート：
- `useSortedClasses`ルールをreact-componentsで有効化
- tv, cx, cn関数に対応
- ルート設定から削除し、パッケージ固有の設定に移行

## CIでチェックできなかった項目

### 確認が必要

- [ ] CLAUDE.mdの内容が適切であること
- [ ] Linter設定が正しく動作すること

### 特記事項

- このPRはドキュメントとLinter設定のみの変更のため、アプリケーションの動作には影響しません

## 補足

### なぜパッケージ固有のCLAUDE.mdを作成したか

- packages/react-componentsは**Web専用**（React DOM）
- React Native（iOS）向けは別パッケージ（packages/react-native-components）で管理予定
- パッケージごとに異なる規約が必要なため、スコープを明確にした

### useSortedClassesルールについて

- ルート設定から削除: 全プロジェクトで有効化する必要がないため
- react-componentsで有効化: tv, cx, cn関数を使用するため
- 今後他のパッケージでも必要に応じて個別に有効化可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)