### PR TITLE
refactor: globals.cssから重複するTailwind @sourceディレクティブを削除

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,4 +1,3 @@
 @import "@next-lift/tailwind-config/tailwind.css";
 
-@source "../../**/*.{js,ts,jsx,tsx}";
 @source "../../../../packages/react-components/src/**/*.{js,ts,jsx,tsx}";


### PR DESCRIPTION
# 概要

Tailwind設定を`tailwind-config`パッケージに集約したため、`apps/web/src/app/globals.css`内の重複する`@source`ディレクティブを削除しました。

## この変更による影響

- **開発者への影響**: Tailwindのソース設定が`tailwind-config`パッケージに一元化され、メンテナンスが容易になります
- **ユーザーへの影響**: なし（内部的なリファクタリングのため）

## CIでチェックできなかった項目

- Tailwindのビルドが正常に動作すること（開発サーバーで確認済み）

## 補足

この変更は #280 のリファクタリングの続きです。`tailwind-config`パッケージ側で必要なソースファイルは既に定義されているため、`apps/web`内で個別に指定する必要がなくなりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)