### PR TITLE
refactor: CSS変数名をbg/fgに統一

### DIFF
--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -72,8 +72,8 @@
 }
 
 body {
-	background: var(--background);
-	color: var(--foreground);
+	background-color: var(--bg);
+	color: var(--fg);
 	font-family: Arial, Helvetica, sans-serif;
 }
 


### PR DESCRIPTION
# 概要

CSS変数名を `background/foreground` から `bg/fg` に統一しました。

## この変更による影響

- 開発者への影響: CSS変数の命名規則が統一され、可読性が向上します
- ユーザーへの影響: なし（表示に変化はありません）

## CIでチェックできなかった項目

- ブラウザでの表示確認（背景色とテキスト色が正しく適用されているか）

## 補足

他のCSS変数（`--fg`, `--muted-fg`, `--border` など）との命名規則を統一するための変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)