### PR TITLE
fix: Sentryエラー対応のためpnpm hoisting設定を追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
 save-exact=true
 strict-peer-dependencies=true
 save-workspace-protocol=rolling
+
+# Sentry使用時の "Package require-in-the-middle can't be external" エラー対応
+# https://docs.sentry.io/platforms/javascript/guides/nextjs/troubleshooting/
+public-hoist-pattern[]=*import-in-the-middle*
+public-hoist-pattern[]=*require-in-the-middle*


### PR DESCRIPTION
# 概要

Sentryの公式ドキュメントに従い、`.npmrc`に`require-in-the-middle`と`import-in-the-middle`パッケージのhoisting設定を追加しました。

これにより、Next.jsアプリケーションでSentryを使用する際に発生する以下のエラーが解消されます:

```
Package require-in-the-middle can't be external
```

参考: https://docs.sentry.io/platforms/javascript/guides/nextjs/troubleshooting/

## この変更による影響

- **開発者への影響**: `pnpm install`を実行すると、`require-in-the-middle`と`import-in-the-middle`パッケージがルートレベルにhoistされます
- **アプリケーションへの影響**: Sentryが正常に動作するようになり、エラートラッキングが機能します
- **ユーザーへの影響**: なし

## CIでチェックできなかった項目

- Sentryが正常に動作することの確認
- 実際のエラートラッキングが機能することの確認

## 補足

この設定は、pnpmのworkspace構成でSentryを使用する際に必要な標準的な対応です。