### PR TITLE
feat: OAuth認証エラーハンドリングUI実装（Phase 2）

### DIFF
--- a/apps/web/src/app/auth/login/_actions/sign-in-with-google.ts
+++ b/apps/web/src/app/auth/login/_actions/sign-in-with-google.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import type { AuthenticationError } from "@next-lift/authentication/errors";
+import {
+	NetworkError,
+	OAuthProviderError,
+} from "@next-lift/authentication/errors";
+import { auth } from "@next-lift/authentication/instance";
+import { R } from "@praha/byethrow";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { reportAuthenticationError } from "../../../../lib/report-authentication-error";
+
+type State = { error: AuthenticationError | null };
+
+export const signInWithGoogle = async (
+	_prevState: State,
+	_formData: FormData,
+): Promise<{ error: AuthenticationError | null }> => {
+	const signInFn = R.try({
+		try: async (): Promise<void> => {
+			await auth.api.signInSocial({
+				body: {
+					provider: "google",
+				},
+				headers: await headers(),
+			});
+		},
+		catch: (error): OAuthProviderError | NetworkError => {
+			// Better Authのエラーを分類
+			if (error instanceof Error && error.message.includes("network")) {
+				return new NetworkError({ cause: error });
+			}
+			const errorMessage = error instanceof Error ? error.message : undefined;
+			return new OAuthProviderError({
+				provider: "google",
+				...(errorMessage && { code: errorMessage }),
+				cause: error,
+			});
+		},
+	});
+
+	const result = await signInFn();
+
+	if (R.isFailure(result)) {
+		reportAuthenticationError(result.error);
+		return { error: result.error };
+	}
+
+	redirect("/dashboard");
+};

--- a/apps/web/src/app/auth/login/_components/google-sign-in-button.tsx
+++ b/apps/web/src/app/auth/login/_components/google-sign-in-button.tsx
@@ -1,30 +1,28 @@
 "use client";
 
-import { Button } from "@next-lift/react-components/ui";
-import { useState } from "react";
-import { authClient } from "../../../../lib/auth-client";
+import { Button, ErrorAlert } from "@next-lift/react-components/ui";
+import { useActionState } from "react";
+import { formatAuthenticationError } from "../../../../lib/format-authentication-error";
+import { signInWithGoogle } from "../_actions/sign-in-with-google";
 
 export const GoogleSignInButton = () => {
-	const [isPending, setIsPending] = useState(false);
-
-	const handleGoogleSignIn = async () => {
-		setIsPending(true);
-		// リダイレクトされるまでpending状態を維持
-		// ページ遷移後はこのコンポーネントごと消えるので、setIsPending(false)は不要
-		try {
-			await authClient.signIn.social({
-				provider: "google",
-				callbackURL: "/dashboard",
-			});
-		} catch (error) {
-			console.error("Google sign in failed:", error);
-			setIsPending(false); // エラー時のみpending状態を解除
-		}
-	};
+	const [state, formAction, isPending] = useActionState(signInWithGoogle, {
+		error: null,
+	});
 
 	return (
-		<Button onClick={handleGoogleSignIn} isDisabled={isPending}>
-			{isPending ? "ログイン中..." : "Googleでログイン"}
-		</Button>
+		<div>
+			{state.error && (
+				<ErrorAlert
+					message={formatAuthenticationError(state.error)}
+					className="mb-4"
+				/>
+			)}
+			<form action={formAction}>
+				<Button type="submit" isDisabled={isPending}>
+					{isPending ? "ログイン中..." : "Googleでログイン"}
+				</Button>
+			</form>
+		</div>
 	);
 };

--- a/apps/web/src/app/dashboard/_components/sign-out-button.tsx
+++ b/apps/web/src/app/dashboard/_components/sign-out-button.tsx
@@ -1,19 +1,28 @@
 "use client";
 
-import { Button } from "@next-lift/react-components/ui";
+import { Button, ErrorAlert } from "@next-lift/react-components/ui";
 import { useActionState } from "react";
+import { formatAuthenticationError } from "../../../lib/format-authentication-error";
 import { signOut } from "../_actions/sign-out";
 
 export const SignOutButton = () => {
-	const [_state, formAction, isPending] = useActionState(signOut, {
+	const [state, formAction, isPending] = useActionState(signOut, {
 		error: null,
 	});
 
 	return (
-		<form action={formAction}>
-			<Button type="submit" intent="outline" isDisabled={isPending}>
-				{isPending ? "ログアウト中..." : "ログアウト"}
-			</Button>
-		</form>
+		<div>
+			{state.error && (
+				<ErrorAlert
+					message={formatAuthenticationError(state.error)}
+					className="mb-4"
+				/>
+			)}
+			<form action={formAction}>
+				<Button type="submit" intent="outline" isDisabled={isPending}>
+					{isPending ? "ログアウト中..." : "ログアウト"}
+				</Button>
+			</form>
+		</div>
 	);
 };

--- a/apps/web/src/lib/format-authentication-error.ts
+++ b/apps/web/src/lib/format-authentication-error.ts
@@ -1,0 +1,23 @@
+import type { AuthenticationError } from "@next-lift/authentication/errors";
+
+/**
+ * 認証エラーをユーザー向けメッセージに変換
+ */
+export const formatAuthenticationError = (
+	error: AuthenticationError,
+): string => {
+	switch (error.name) {
+		case "OAuthProviderError":
+			return `${error.provider}での認証に失敗しました。もう一度お試しください。`;
+		case "OAuthCancelledError":
+			return "認証がキャンセルされました。";
+		case "NetworkError":
+			return "ネットワークエラーが発生しました。接続を確認してください。";
+		case "SessionError":
+			return "セッションの処理に失敗しました。もう一度お試しください。";
+		case "DatabaseError":
+			return "サーバーエラーが発生しました。しばらくしてからお試しください。";
+		case "InvalidConfigurationError":
+			return "システム設定エラーが発生しました。管理者にお問い合わせください。";
+	}
+};

--- a/packages/react-components/src/ui/error-alert.tsx
+++ b/packages/react-components/src/ui/error-alert.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { FC } from "react";
+import { twMerge } from "tailwind-merge";
+import { tv } from "tailwind-variants";
+
+const errorAlertStyles = tv({
+	slots: {
+		container: [
+			"relative rounded-lg border border-danger bg-danger/10 p-4",
+			"[--alert-fg:var(--color-danger-fg)]",
+		],
+		header: "flex items-start justify-between gap-2",
+		title: "font-medium text-(--alert-fg)",
+		closeButton: [
+			"shrink-0 rounded-sm opacity-70 transition-opacity",
+			"hover:opacity-100",
+			"focus:outline-0 focus-visible:ring-2 focus-visible:ring-danger",
+			"text-(--alert-fg)",
+		],
+		message: "mt-2 text-(--alert-fg)/90 text-sm",
+	},
+});
+
+const styles = errorAlertStyles();
+
+type Props = {
+	title?: string;
+	message: string;
+	onClose?: () => void;
+	className?: string;
+};
+
+export const ErrorAlert: FC<Props> = ({
+	title = "エラー",
+	message,
+	onClose,
+	className,
+}) => {
+	return (
+		<div role="alert" className={twMerge(styles.container(), className)}>
+			<div className={styles.header()}>
+				<span className={styles.title()}>{title}</span>
+				{onClose && (
+					<button
+						onClick={onClose}
+						type="button"
+						aria-label="閉じる"
+						className={styles.closeButton()}
+					>
+						×
+					</button>
+				)}
+			</div>
+			<p className={styles.message()}>{message}</p>
+		</div>
+	);
+};

--- a/packages/react-components/src/ui/index.ts
+++ b/packages/react-components/src/ui/index.ts
@@ -1,2 +1,3 @@
 export * from "./button";
+export * from "./error-alert";
 export * from "./link";


### PR DESCRIPTION
# 概要

OAuth認証エラーハンドリングのPhase 2を実装しました。Phase 1（#357）で確立したエラー型定義とSentry送信ロジックをもとに、UI側のエラーハンドリングを完成させました。

申し送り書（`apps/web/docs/oauth-error-handling-handoff.md`）に従い、以下を実装：
- エラーメッセージマッピング関数
- エラー表示UIコンポーネント（ErrorAlert）
- Google OAuth認証のServer Action化
- SignOutButtonのエラー表示対応

## この変更による影響

### アプリケーションを利用するユーザーへの影響

- **Google認証時のエラー表示**: Google認証でエラーが発生した際、具体的なエラーメッセージが表示されるようになります
  - 例: "googleでの認証に失敗しました。もう一度お試しください。"
  - 例: "ネットワークエラーが発生しました。接続を確認してください。"
- **サインアウト時のエラー表示**: サインアウトでエラーが発生した際、エラーメッセージが表示されるようになります

### 開発者への影響

- **新しいUIコンポーネント**: `ErrorAlert`コンポーネントが追加され、他の機能でも使用可能になりました
- **Google認証のパターン変更**: クライアント側の直接呼び出しからServer Action使用に変更されました

## CIでチェックできなかった項目

以下のエラーケースの手動テストが必要です：

- [ ] ネットワークエラー（Dev Toolsでネットワークをオフライン）
- [ ] サーバーエラー（Better Authのエラーを意図的に発生）
- [ ] セッション期限切れ
- [ ] ユーザーによる認証キャンセル（Google OAuth画面でキャンセル）

## 補足

### 実装の詳細

**エラーメッセージマッピング**
- `apps/web/src/lib/format-authentication-error.ts`
- 6つのエラー型を日本語メッセージに変換

**ErrorAlertコンポーネント**
- `packages/react-components/src/ui/error-alert.tsx`
- tailwind-variantsでスタイリング（既存Buttonと同じ方針）

**Google OAuth認証のServer Action化**
- `apps/web/src/app/auth/login/_actions/sign-in-with-google.ts`
- `@praha/byethrow`の`R.try()`でエラーハンドリング
- Better AuthのエラーをOAuthProviderError/NetworkErrorに分類
- Sentry送信（サーバー系エラーのみ）

### 関連

- Phase 1実装: #357
- 申し送り書: `apps/web/docs/oauth-error-handling-handoff.md`
- ADR-018: Sentryエラーレポーティング規約