### PR TITLE
feat: Apple OAuth認証を実装

### DIFF
--- a/apps/web/src/app/auth/sign-in/_components/apple-sign-in-button.tsx
+++ b/apps/web/src/app/auth/sign-in/_components/apple-sign-in-button.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Button, ErrorAlert } from "@next-lift/react-components/ui";
+import { R } from "@praha/byethrow";
+import { type FC, use, useActionState } from "react";
+import { signInWithApple } from "../_mutations/sign-in-with-apple";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+type Props = {
+	searchParams?: SearchParams;
+};
+
+export const AppleSignInButton: FC<Props> = ({ searchParams }) => {
+	const [state, action, pending] = useActionState(signInWithApple, undefined);
+	const searchParamsErrors = searchParams
+		? getSearchParamsErrors(searchParams)
+		: [];
+
+	return (
+		<form action={action} className="space-y-4">
+			{state && R.isFailure(state) && (
+				<ErrorAlert>Appleでサインインに失敗しました</ErrorAlert>
+			)}
+			{searchParamsErrors.length > 0 && (
+				<ul>
+					{searchParamsErrors.map((error) => (
+						<li key={error}>
+							<ErrorAlert>{formatSearchParamsError(error)}</ErrorAlert>
+						</li>
+					))}
+				</ul>
+			)}
+			<Button type="submit" isDisabled={pending}>
+				{pending ? "サインイン中..." : "Appleでサインイン"}
+			</Button>
+		</form>
+	);
+};
+
+export const AppleSignInButtonSkeleton: FC = () => {
+	return <Button isDisabled>Appleでサインイン</Button>;
+};
+
+const getSearchParamsErrors = (searchParams: SearchParams): string[] => {
+	// biome-ignore lint/complexity/useLiteralKeys: index signatureへのアクセスにはブラケット記法が必要
+	const error = use(searchParams)["error"];
+	const errors =
+		error === undefined ? [] : Array.isArray(error) ? error : [error];
+
+	return [...new Set(errors)];
+};
+
+const formatSearchParamsError = (error: string): string => {
+	switch (error) {
+		case "access_denied":
+			return "Appleアカウントでのサインインがキャンセルされました。";
+		default:
+			return "サインインに失敗しました。";
+	}
+};

--- a/apps/web/src/app/auth/sign-in/_mutations/sign-in-with-apple.ts
+++ b/apps/web/src/app/auth/sign-in/_mutations/sign-in-with-apple.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { auth } from "@next-lift/authentication/instance";
+import { publicEnv } from "@next-lift/env/public";
+import { R } from "@praha/byethrow";
+import { ErrorFactory } from "@praha/error-factory";
+import * as Sentry from "@sentry/nextjs";
+import type { Route } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+class SignInWithAppleError extends ErrorFactory({
+	name: "SignInWithAppleError",
+	message: "Sign in with Apple failed",
+}) {}
+
+type State = R.Result<string, SignInWithAppleError> | undefined;
+
+export const signInWithApple = async (_prevState: State, _formData: FormData) =>
+	R.pipe(
+		R.try({
+			immediate: true,
+			try: async () => {
+				const { url } = await auth.api.signInSocial({
+					headers: await headers(),
+					body: {
+						provider: "apple",
+						callbackURL: "/dashboard",
+						errorCallbackURL: `${publicEnv.NEXT_PUBLIC_BETTER_AUTH_URL}/auth/sign-in`,
+					},
+				});
+
+				if (!url) {
+					throw new Error("認証URLの取得に失敗しました");
+				}
+
+				return url;
+			},
+			catch: (error) => {
+				const signInError = new SignInWithAppleError({ cause: error });
+				Sentry.captureException(signInError);
+
+				return signInError;
+			},
+		}),
+		R.inspect((url) => {
+			redirect(url as Route);
+		}),
+	);

--- a/apps/web/src/app/auth/sign-in/page.tsx
+++ b/apps/web/src/app/auth/sign-in/page.tsx
@@ -1,5 +1,9 @@
 import { type FC, Suspense } from "react";
 import {
+	AppleSignInButton,
+	AppleSignInButtonSkeleton,
+} from "./_components/apple-sign-in-button";
+import {
 	GoogleSignInButton,
 	GoogleSignInButtonSkeleton,
 } from "./_components/google-sign-in-button";
@@ -13,9 +17,14 @@ const Page: FC<PageProps<"/auth/sign-in">> = async ({ searchParams }) => {
 						サインイン（動作確認用）
 					</h1>
 				</header>
-				<Suspense fallback={<GoogleSignInButtonSkeleton />}>
-					<GoogleSignInButton searchParams={searchParams} />
-				</Suspense>
+				<div className="space-y-4">
+					<Suspense fallback={<GoogleSignInButtonSkeleton />}>
+						<GoogleSignInButton searchParams={searchParams} />
+					</Suspense>
+					<Suspense fallback={<AppleSignInButtonSkeleton />}>
+						<AppleSignInButton searchParams={searchParams} />
+					</Suspense>
+				</div>
 			</section>
 		</main>
 	);

--- a/docs/project/001-infra.md
+++ b/docs/project/001-infra.md
@@ -68,10 +68,10 @@
   - [x] エラー通知の設定
   - [x] エラー送信のテスト
 
-- [ ] Apple Developer Programのセットアップ（OAuth認証用）
+- [x] Apple Developer Programのセットアップ（OAuth認証用）
   - [x] Apple Developer Programへの登録
-  - [ ] OAuth認証用のServices IDとクレデンシャル作成
-  - [ ] リダイレクトURLの設定（ローカル/本番/プレビュー）
+  - [x] OAuth認証用のServices IDとクレデンシャル作成
+  - [x] リダイレクトURLの設定（本番のみ、ローカルはApple非対応）
 
 - [x] Google Cloud Consoleのセットアップ（OAuth認証用）
   - [x] Google Cloud Projectの作成
@@ -83,7 +83,7 @@
     - [x] Better AuthのRoute Handlerの作成
     - [x] apps/web内でのBetter Auth設定
       - [x] packages/authenticationのBetter Authインスタンスを利用
-      - [x] プロバイダー設定の追加（Google）
+      - [x] プロバイダー設定の追加（Google, Apple）
     - [x] 環境変数の設定
       - [x] ローカル開発環境（.env）
       - [ ] Vercel環境変数（本番/プレビュー）
@@ -96,7 +96,7 @@
       - [x] サインインページの作成
       - [x] Google OAuth認証の実装
       - [x] 認証コールバックの動作確認
-    - [ ] Apple OAuth認証のサインインフロー確認（Apple Developer Program承認待ち）
+    - [ ] Apple OAuth認証のサインインフロー確認（本番環境でテスト予定）
     - [x] 初回サインイン時のユーザー作成確認
     - [x] 2回目以降のサインイン確認
     - [x] セッション管理の確認

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -21,7 +21,8 @@
 		"@next-lift/env": "workspace:*",
 		"@next-lift/utilities": "workspace:*",
 		"better-auth": "1.4.3",
-		"drizzle-orm": "0.44.7"
+		"drizzle-orm": "0.44.7",
+		"jose": "6.1.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.6",

--- a/packages/authentication/src/instance.ts
+++ b/packages/authentication/src/instance.ts
@@ -4,6 +4,7 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
 import * as schema from "./generated/schema";
+import { generateAppleClientSecret } from "./libs/generate-apple-client-secret";
 import { getDatabase } from "./libs/get-database";
 
 export const auth = createLazyProxy(() => {
@@ -13,6 +14,13 @@ export const auth = createLazyProxy(() => {
 			schema,
 		}),
 		socialProviders: {
+			apple: {
+				clientId: env.APPLE_CLIENT_ID,
+				// Better Authは内部でPromiseをawaitするため、getterでPromiseを返すことで動的生成が可能
+				get clientSecret() {
+					return generateAppleClientSecret();
+				},
+			} as unknown as { clientId: string; clientSecret: string },
 			google: {
 				clientId: env.GOOGLE_CLIENT_ID,
 				clientSecret: env.GOOGLE_CLIENT_SECRET,
@@ -21,7 +29,7 @@ export const auth = createLazyProxy(() => {
 		baseURL: env.BETTER_AUTH_URL,
 		secret: env.BETTER_AUTH_SECRET,
 		plugins: [nextCookies()],
-		trustedOrigins: [env.BETTER_AUTH_URL],
+		trustedOrigins: [env.BETTER_AUTH_URL, "https://appleid.apple.com"],
 		onAPIError: {
 			errorURL: "/auth/sign-in",
 		},

--- a/packages/authentication/src/libs/generate-apple-client-secret.ts
+++ b/packages/authentication/src/libs/generate-apple-client-secret.ts
@@ -1,0 +1,29 @@
+import { env } from "@next-lift/env/private";
+import { importPKCS8, SignJWT } from "jose";
+
+/**
+ * Apple OAuth認証用のclientSecretを生成する
+ *
+ * AppleのOAuth認証では、clientSecretとしてJWTを使用する必要がある。
+ * このJWTは認証リクエストごとに生成され、Appleサーバーとの認証に使用される。
+ * ユーザーのセッションとは無関係であり、JWTの有効期限が切れても
+ * ユーザーのログイン状態には影響しない。
+ */
+export const generateAppleClientSecret = async (): Promise<string> => {
+	const privateKey = await importPKCS8(env.APPLE_PRIVATE_KEY, "ES256");
+	const now = Math.floor(Date.now() / 1000);
+
+	// 有効期限は1時間（実際の認証は数秒で完了するため十分）
+	const expirationTime = now + 60 * 60;
+
+	const jwt = await new SignJWT({})
+		.setProtectedHeader({ alg: "ES256", kid: env.APPLE_KEY_ID })
+		.setIssuedAt(now)
+		.setExpirationTime(expirationTime)
+		.setIssuer(env.APPLE_TEAM_ID)
+		.setAudience("https://appleid.apple.com")
+		.setSubject(env.APPLE_CLIENT_ID)
+		.sign(privateKey);
+
+	return jwt;
+};

--- a/packages/env/src/schemas/apple-authentication.ts
+++ b/packages/env/src/schemas/apple-authentication.ts
@@ -1,0 +1,13 @@
+import z from "zod";
+import type { Schemas } from "./type";
+
+export const appleAuthenticationEnvSchemas = {
+	privateBuild: z.object({
+		APPLE_CLIENT_ID: z.string().min(1),
+		APPLE_TEAM_ID: z.string().length(10),
+		APPLE_KEY_ID: z.string().length(10),
+		APPLE_PRIVATE_KEY: z.string().min(1),
+	}),
+	privateRuntime: z.object({}),
+	publicRuntime: z.object({}),
+} as const satisfies Schemas;

--- a/packages/env/src/schemas/index.ts
+++ b/packages/env/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { appleAuthenticationEnvSchemas } from "./apple-authentication";
 import { betterAuthEnvSchemas } from "./better-auth";
 import { githubActionsEnvSchemas } from "./github-actions";
 import { googleAuthenticationEnvSchemas } from "./google-authentication";
@@ -11,6 +12,7 @@ export type PrivateRuntimeEnv = z.infer<typeof privateRuntimeEnvSchema>;
 export type PublicRuntimeEnv = z.infer<typeof publicRuntimeEnvSchema>;
 
 export const privateBuildEnvSchema = z.object({
+	...appleAuthenticationEnvSchemas.privateBuild.shape,
 	...betterAuthEnvSchemas.privateBuild.shape,
 	...githubActionsEnvSchemas.privateBuild.shape,
 	...googleAuthenticationEnvSchemas.privateBuild.shape,
@@ -20,6 +22,7 @@ export const privateBuildEnvSchema = z.object({
 });
 
 export const privateRuntimeEnvSchema = z.object({
+	...appleAuthenticationEnvSchemas.privateRuntime.shape,
 	...betterAuthEnvSchemas.privateRuntime.shape,
 	...githubActionsEnvSchemas.privateRuntime.shape,
 	...googleAuthenticationEnvSchemas.privateRuntime.shape,
@@ -29,6 +32,7 @@ export const privateRuntimeEnvSchema = z.object({
 });
 
 export const publicRuntimeEnvSchema = z.object({
+	...appleAuthenticationEnvSchemas.publicRuntime.shape,
 	...betterAuthEnvSchemas.publicRuntime.shape,
 	...githubActionsEnvSchemas.publicRuntime.shape,
 	...googleAuthenticationEnvSchemas.publicRuntime.shape,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       drizzle-orm:
         specifier: 0.44.7
         version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(kysely@0.28.8)
+      jose:
+        specifier: 6.1.2
+        version: 6.1.2
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.6
@@ -4190,8 +4193,8 @@ packages:
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
 
-  jose@6.1.0:
-    resolution: {integrity: sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==}
+  jose@6.1.2:
+    resolution: {integrity: sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ==}
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
@@ -5819,20 +5822,20 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.0)(kysely@0.28.8)(nanostores@1.0.1)':
+  '@better-auth/core@1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.2)(kysely@0.28.8)(nanostores@1.0.1)':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
       '@standard-schema/spec': 1.0.0
       better-call: 1.1.0
-      jose: 6.1.0
+      jose: 6.1.2
       kysely: 0.28.8
       nanostores: 1.0.1
       zod: 4.1.13
 
-  '@better-auth/telemetry@1.4.3(@better-auth/core@1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.0)(kysely@0.28.8)(nanostores@1.0.1))':
+  '@better-auth/telemetry@1.4.3(@better-auth/core@1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.2)(kysely@0.28.8)(nanostores@1.0.1))':
     dependencies:
-      '@better-auth/core': 1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.0)(kysely@0.28.8)(nanostores@1.0.1)
+      '@better-auth/core': 1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.2)(kysely@0.28.8)(nanostores@1.0.1)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
 
@@ -9117,8 +9120,8 @@ snapshots:
 
   better-auth@1.4.3:
     dependencies:
-      '@better-auth/core': 1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.0)(kysely@0.28.8)(nanostores@1.0.1)
-      '@better-auth/telemetry': 1.4.3(@better-auth/core@1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.0)(kysely@0.28.8)(nanostores@1.0.1))
+      '@better-auth/core': 1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.2)(kysely@0.28.8)(nanostores@1.0.1)
+      '@better-auth/telemetry': 1.4.3(@better-auth/core@1.4.3(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.1.0)(jose@6.1.2)(kysely@0.28.8)(nanostores@1.0.1))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.18
       '@noble/ciphers': 2.0.1
@@ -9126,7 +9129,7 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       better-call: 1.1.0
       defu: 6.1.4
-      jose: 6.1.0
+      jose: 6.1.2
       kysely: 0.28.8
       nanostores: 1.0.1
       zod: 4.1.13
@@ -10088,7 +10091,7 @@ snapshots:
 
   jose@5.9.6: {}
 
-  jose@6.1.0: {}
+  jose@6.1.2: {}
 
   js-base64@3.7.8: {}
 


### PR DESCRIPTION
# 概要

Better AuthにApple OAuth認証を追加し、サインインページにAppleサインインボタンを配置した。

## 変更内容

- 環境変数スキーマ（APPLE_CLIENT_ID, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY）を追加
- joseライブラリを使用したclientSecret JWT動的生成を実装
  - Appleの要件により、clientSecretは認証リクエストごとにJWTを生成する方式を採用
  - 有効期限は1時間（認証処理自体は数秒で完了するため十分）
- サインインページにAppleサインインボタンを追加
- タスクドキュメント（001-infra.md）を更新

## この変更による影響

- ユーザーがAppleアカウントでサインインできるようになる
- ローカル開発環境ではApple認証は動作しない（Appleのドメイン制約のため、プレビュー/本番環境でのみ動作確認可能）

## CIでチェックできなかった項目

以下の手順でプレビュー環境での動作確認が必要：

### 1. Vercel環境変数の設定

| 環境変数 | 値 |
|---------|-----|
| APPLE_CLIENT_ID | `training.next-lift.web` |
| APPLE_TEAM_ID | `M962QB54YW` |
| APPLE_KEY_ID | `K48DPCBM9S` |
| APPLE_PRIVATE_KEY | .p8ファイルの内容（改行含む） |

### 2. Apple Developer Consoleでのドメイン設定

1. [Apple Developer Console](https://developer.apple.com/account/resources/identifiers/list/serviceId) にアクセス
2. `training.next-lift.web` を選択 → Configure
3. Domains and Subdomains にプレビューURLのドメインを追加
4. Return URLs に `https://<preview-domain>/api/auth/callback/apple` を追加

### 動作確認手順

1. プレビュー環境のサインインページにアクセス
2. 「Appleでサインイン」ボタンをクリック
3. Appleの認証画面にリダイレクトされることを確認
4. Apple IDでログインし、ダッシュボードにリダイレクトされることを確認

## 補足

- clientSecretのJWT有効期限（1時間）は、ユーザーのセッションとは無関係。JWTはAppleサーバーとの認証に使用するもので、ユーザーのログイン状態には影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)