### PR TITLE
bugfix: Apple OAuth JWT生成のデバッグログを追加

### DIFF
--- a/packages/authentication/src/libs/generate-apple-client-secret.ts
+++ b/packages/authentication/src/libs/generate-apple-client-secret.ts
@@ -18,6 +18,19 @@ export const generateAppleClientSecret = async (): Promise<string> => {
 	// 有効期限は1時間（実際の認証は数秒で完了するため十分）
 	const expirationTime = now + 60 * 60;
 
+	// デバッグ: JWT生成に使用する値をログ出力
+	console.log("[Apple JWT Debug]", {
+		kid: env.APPLE_KEY_ID,
+		iss: env.APPLE_TEAM_ID,
+		sub: env.APPLE_CLIENT_ID,
+		aud: "https://appleid.apple.com",
+		iat: now,
+		exp: expirationTime,
+		privateKeyLength: privateKeyPem.length,
+		privateKeyStartsWith: privateKeyPem.substring(0, 30),
+		privateKeyEndsWith: privateKeyPem.substring(privateKeyPem.length - 30),
+	});
+
 	const jwt = await new SignJWT({})
 		.setProtectedHeader({ alg: "ES256", kid: env.APPLE_KEY_ID })
 		.setIssuedAt(now)
@@ -26,6 +39,12 @@ export const generateAppleClientSecret = async (): Promise<string> => {
 		.setAudience("https://appleid.apple.com")
 		.setSubject(env.APPLE_CLIENT_ID)
 		.sign(privateKey);
+
+	// デバッグ: 生成されたJWTのヘッダーとペイロードを確認
+	const parts = jwt.split(".");
+	const header = Buffer.from(parts[0] ?? "", "base64url").toString();
+	const payload = Buffer.from(parts[1] ?? "", "base64url").toString();
+	console.log("[Apple JWT Generated]", { header, payload });
 
 	return jwt;
 };


### PR DESCRIPTION
# 概要

Apple OAuth認証の`invalid_client`エラーを調査するため、JWT生成時のデバッグログを追加。

## この変更による影響

- Vercelのログで以下の情報が確認できるようになる：
  - JWT生成に使用している環境変数の値（kid, iss, sub）
  - 秘密鍵の長さと先頭/末尾の文字列
  - 生成されたJWTのヘッダーとペイロード

## CIでチェックできなかった項目

- 本番環境でApple認証を試行し、Vercelログでデバッグ情報を確認

## 補足

- このPRは調査目的の一時的な変更。問題解決後にデバッグログは削除予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)