### PR TITLE
debug: BETTER_AUTH_URLをログに追加

### DIFF
--- a/packages/authentication/src/libs/generate-apple-client-secret.ts
+++ b/packages/authentication/src/libs/generate-apple-client-secret.ts
@@ -20,6 +20,7 @@ export const generateAppleClientSecret = async (): Promise<string> => {
 
 	// デバッグ: JWT生成に使用する値をログ出力
 	console.log("[Apple JWT Debug]", {
+		betterAuthUrl: env.BETTER_AUTH_URL,
 		kid: env.APPLE_KEY_ID,
 		iss: env.APPLE_TEAM_ID,
 		sub: env.APPLE_CLIENT_ID,


### PR DESCRIPTION
# 概要

Apple OAuthの`invalid_client`エラーのデバッグのため、`BETTER_AUTH_URL`環境変数の値をログに出力する。

## この変更による影響

- 本番環境のログに`BETTER_AUTH_URL`の値が出力されるようになる
- デバッグ完了後に削除予定

## CIでチェックできなかった項目

- 本番環境でApple Sign Inを試行し、ログで`betterAuthUrl`の値を確認する

## 補足

redirect_uriの不一致が疑われるため、サーバー側で使用されている`BETTER_AUTH_URL`の値を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)