### PR TITLE
fix: account linkingが動作しない問題を修正

### DIFF
--- a/packages/authentication/src/instance.ts
+++ b/packages/authentication/src/instance.ts
@@ -29,6 +29,7 @@ export const auth = createLazyProxy(() => {
 		account: {
 			accountLinking: {
 				enabled: true,
+				trustedProviders: ["google", "apple"],
 			},
 		},
 		user: {


### PR DESCRIPTION
# 概要

Better Authで`accountLinking.enabled: true`を設定しているにもかかわらず、同じメールアドレスで異なるプロバイダー（Google/Apple）からサインインすると、1つのuserに2つのaccountが紐づくのではなく、2つの別々のuserが作成される問題を修正。

**原因**: `trustedProviders`が設定されていなかったため、Better Authがプロバイダーを「信頼できる」と認識していなかった。

**修正内容**: `trustedProviders: ["google", "apple"]`を追加。

## この変更による影響

- 同じメールアドレスでGoogle/Appleの両方からサインインした場合、自動的に同一ユーザーとしてアカウントがリンクされるようになる
- 既存ユーザーには影響なし（新規リンクのみ対象）

## CIでチェックできなかった項目

- 実際のGoogle/Apple OAuthフローでaccount linkingが正しく動作するかの確認
  1. Googleでサインイン → userとaccountが1つずつ作成されることを確認
  2. サインアウト
  3. 同じメールアドレスのAppleでサインイン
  4. Tursoで確認：userが1つ、accountが2つ（両方同じuserIdを共有）

## 補足

GoogleとAppleはどちらも内部でメール検証を行う信頼できるプロバイダーのため、`trustedProviders`に追加してもセキュリティ上の問題はない（ADR-019でも同様の判断）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)