### PR TITLE
chore: Preview DBの命名規則をプロジェクト名付きに統一

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -19,7 +19,7 @@ jobs:
           TURSO_ORG_SLUG: ${{ secrets.TURSO_ORG_SLUG }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          DB_NAME="preview-pr${PR_NUMBER}-auth"
+          DB_NAME="next-lift-preview-pr${PR_NUMBER}-auth"
 
           # データベースを削除
           DELETE_RESPONSE=$(curl -X DELETE \
@@ -83,7 +83,7 @@ jobs:
               '',
               '✅ プレビュー環境をクリーンアップしました！',
               '',
-              `**Database Name**: preview-pr${prNumber}-auth`,
+              `**Database Name**: next-lift-preview-pr${prNumber}-auth`,
               '',
               '> PRがクローズされたため、関連するデータベースとVercel環境変数を自動的に削除しました。'
             ].join('\n');

--- a/.github/workflows/setup-preview.yml
+++ b/.github/workflows/setup-preview.yml
@@ -44,7 +44,7 @@ jobs:
           TURSO_GROUP: ${{ secrets.TURSO_GROUP }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          DB_NAME="preview-pr${PR_NUMBER}-auth"
+          DB_NAME="next-lift-preview-pr${PR_NUMBER}-auth"
 
           # データベースを作成（既に存在する場合はエラーになるが続行）
           CREATE_RESPONSE=$(curl -s -X POST \


### PR DESCRIPTION
# 概要

Per-User Database導入に向けて、Preview環境のDB命名規則を `next-lift-` プレフィックス付きに変更。
本番/プレビュー/開発環境で一貫した命名規則を適用するための準備。

- `preview-pr{N}-auth` → `next-lift-preview-pr{N}-auth`

## この変更による影響

- 既存のPreviewデータベースに影響なし（新規PR作成時から適用）
- Tursoダッシュボード上でDBがプロジェクト名で識別しやすくなる

## CIでチェックできなかった項目

- なし

## 補足

- Per-User Database実装（別PR予定）の先行対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)