### PR TITLE
追加: .references/ディレクトリを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ storybook-static
 # Sentry
 .sentryclirc
 sentry.properties
+
+.references/


### PR DESCRIPTION
# 概要

開発ツールが生成する参照ファイル用ディレクトリ（.references/）をGit管理から除外するため、.gitignoreに追加しました。

## この変更による影響

- 開発者: 開発ツールが生成する参照ファイルがGit管理されなくなり、コミット時のノイズが減ります
- アプリケーション利用者: 影響なし

## CIでチェックできなかった項目

なし

## 補足

なし