### PR TITLE
本番環境のマイグレーション実行方法を簡素化

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -39,29 +39,13 @@ jobs:
           }
 
       - name: Run Database Migration
-        env:
-          TURSO_API_TOKEN: ${{ secrets.TURSO_PLATFORM_API_TOKEN }}
-          TURSO_ORG_SLUG: ${{ secrets.TURSO_ORG_SLUG }}
         run: |
-          DB_NAME="next-lift-production-auth"
+          # Vercel から取得した環境変数を読み込んでマイグレーションを実行
+          set -a
+          source .vercel/.env.production.local
+          set +a
 
-          # データベース情報を取得してURLを構築
-          GET_RESPONSE=$(curl -s \
-            -H "Authorization: Bearer ${TURSO_API_TOKEN}" \
-            "https://api.turso.tech/v1/organizations/${TURSO_ORG_SLUG}/databases/${DB_NAME}")
-          DB_HOSTNAME=$(echo "${GET_RESPONSE}" | jq -r '.database.Hostname')
-          DB_URL="libsql://${DB_HOSTNAME}"
-
-          # 一時トークンを取得（1時間有効）
-          TOKEN_RESPONSE=$(curl -s -X POST \
-            -H "Authorization: Bearer ${TURSO_API_TOKEN}" \
-            "https://api.turso.tech/v1/organizations/${TURSO_ORG_SLUG}/databases/${DB_NAME}/auth/tokens?expiration=1h")
-          DB_AUTH_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.jwt')
-
-          # マイグレーションを実行
           cd packages/authentication
-          TURSO_AUTH_DATABASE_URL="${DB_URL}" \
-          TURSO_AUTH_DATABASE_AUTH_TOKEN="${DB_AUTH_TOKEN}" \
           pnpm migration:apply
           echo "Migration completed successfully"
 


### PR DESCRIPTION
## 概要

本番環境のデプロイワークフローで、Turso Platform APIから動的にDB URLとトークンを取得する方式から、Vercelから取得した環境変数を直接使用する方式に変更しました。

## この変更による影響

- **CI/CDパイプライン**: マイグレーション実行ステップが簡素化され、実行時間が短縮されます
- **環境変数管理**: Vercelの環境変数設定を一元管理できるようになります
- **保守性**: API呼び出しのロジックが不要になり、コードがシンプルになります

## CIでチェックできなかった項目

- 実際の本番環境でのマイグレーション実行の動作確認

## 補足

- Turso Platform APIの呼び出し処理（約20行）を削除し、環境変数の読み込みのみに変更
- Vercelの環境変数（`.vercel/.env.production.local`）が正しく設定されていることを前提としています