### PR TITLE
improve(ci): Vercelデプロイに--archive=tgzを追加

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -55,5 +55,5 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          npx vercel deploy --prod --token=$VERCEL_TOKEN > deployment-url.txt
+          npx vercel deploy --prod --archive=tgz --token=$VERCEL_TOKEN > deployment-url.txt
           echo "DEPLOYMENT_URL=$(cat deployment-url.txt)" >> $GITHUB_ENV

--- a/.github/workflows/setup-preview.yml
+++ b/.github/workflows/setup-preview.yml
@@ -157,7 +157,7 @@ jobs:
           npx vercel build --token=$VERCEL_TOKEN
 
           # --prebuiltデプロイ時に--envでランタイム環境変数を渡す
-          npx vercel deploy --prebuilt --token=$VERCEL_TOKEN \
+          npx vercel deploy --prebuilt --archive=tgz --token=$VERCEL_TOKEN \
             --env APP_ENV="${APP_ENV}" \
             --env BETTER_AUTH_URL="${PREVIEW_URL}" \
             --env TURSO_AUTH_DATABASE_URL="${db_url}" \


### PR DESCRIPTION
# 概要

Vercelデプロイ時に`--archive=tgz`オプションを追加し、Hobbyプランの1日5000ファイルアップロード制限（`api-upload-free`エラー）を回避する。

monorepoでは1回のデプロイで大量のファイルがアップロードされるため、この制限に達しやすい。`--archive=tgz`オプションを使用することで、ファイルを個別にアップロードする代わりにtarballとしてまとめてアップロードできる。

## この変更による影響

- デプロイ時のファイルアップロード方法が変更される（個別 → tarball）
- ユーザーへの影響はなし

## CIでチェックできなかった項目

- 実際にデプロイが成功し、`api-upload-free`エラーが発生しないこと

## 補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)