### PR TITLE
improve: Reactバージョン管理の整理

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -12,14 +12,14 @@
 		"@heroicons/react": "2.2.0",
 		"@next-lift/tailwind-config": "workspace:*",
 		"clsx": "2.1.1",
-		"react": "19.2.4",
 		"react-aria-components": "1.15.1",
-		"react-dom": "19.2.4",
 		"tailwind-merge": "3.4.0",
 		"tailwind-variants": "3.2.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.6",
+		"react": "19.2.4",
+		"react-dom": "19.2.4",
 		"@chromatic-com/storybook": "5.0.1",
 		"@storybook/addon-a11y": "10.2.8",
 		"@storybook/addon-docs": "10.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,15 +340,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      react:
-        specifier: 19.2.4
-        version: 19.2.4
       react-aria-components:
         specifier: 1.15.1
         version: 1.15.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-dom:
-        specifier: 19.2.4
-        version: 19.2.4(react@19.2.4)
       tailwind-merge:
         specifier: 3.4.0
         version: 3.4.0
@@ -407,6 +401,12 @@ importers:
       prop-types:
         specifier: 15.8.1
         version: 15.8.1
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
       storybook:
         specifier: 10.2.8
         version: 10.2.8(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,20 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["github>praha-inc/renovate-config"],
-	"rebaseWhen": "never"
+	"rebaseWhen": "never",
+	"packageRules": [
+		{
+			"description": "iOS側のReact/React Nativeはmajor/minor更新を無効化（Expo SDKアップグレード時に手動更新）",
+			"matchPackageNames": ["react", "react-dom", "react-native", "@types/react"],
+			"matchFileNames": ["apps/ios/**"],
+			"matchUpdateTypes": ["major", "minor"],
+			"enabled": false
+		},
+		{
+			"description": "Web側のReact関連パッケージをグループ化",
+			"groupName": "react packages (web)",
+			"matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+			"matchFileNames": ["apps/web/**", "packages/react-components/**"]
+		}
+	]
 }


### PR DESCRIPTION
# 概要

monorepo内のReactバージョン管理を整理した。

- react-componentsパッケージのreact/react-domをdependenciesからdevDependenciesに移動（peerDependenciesとの重複インストールリスク解消）
- renovate.jsonにiOS側React/React Nativeのmajor/minor自動更新無効化ルールを追加（Expo SDK連動のため手動管理）
- renovate.jsonにWeb側React関連パッケージのグループ化ルールを追加

## この変更による影響

- **react-componentsパッケージの利用者（apps/web）**: reactがpeerDependencies経由で解決されるようになり、バージョン重複のリスクがなくなる。動作に変更なし。
- **Renovateによる自動更新**: iOS側のReact/React Nativeはmajor/minor更新がスキップされ、Expo SDKアップグレード時に手動で更新する運用になる。Web側はreact関連パッケージが一括で更新される。

## CIでチェックできなかった項目

- RenovateのpackageRulesが意図通りに動作するかは、実際にRenovateがPRを作成するタイミングで確認が必要

## 補足

なし