### PR TITLE
improve: iOSアプリからreact-dom依存を削除

### DIFF
--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -29,7 +29,6 @@
 		"expo-status-bar": "3.0.9",
 		"expo-web-browser": "15.0.10",
 		"react": "19.2.4",
-		"react-dom": "19.2.4",
 		"react-native": "0.81.5"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       react:
         specifier: 19.2.4
         version: 19.2.4
-      react-dom:
-        specifier: 19.2.4
-        version: 19.2.4(react@19.2.4)
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.28.5)(@types/react@19.2.14)(react@19.2.4)

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
 	"packageRules": [
 		{
 			"description": "iOS側のReact/React Nativeはmajor/minor更新を無効化（Expo SDKアップグレード時に手動更新）",
-			"matchPackageNames": ["react", "react-dom", "react-native", "@types/react"],
+			"matchPackageNames": ["react", "react-native", "@types/react"],
 			"matchFileNames": ["apps/ios/**"],
 			"matchUpdateTypes": ["major", "minor"],
 			"enabled": false


### PR DESCRIPTION
# 概要

React NativeアプリであるiOSアプリ(`apps/ios`)のdependenciesに不要な`react-dom`が含まれていたため削除。併せてRenovateルールからもiOS向けの`react-dom`を除外。

## この変更による影響

- iOSアプリ: 不要な依存が減り、node_modulesがわずかに軽量化
- Renovateルール: iOS向けのReact更新抑制ルール（Rule 1）から`react-dom`を除外。Web側のReactグループ化ルール（Rule 2）は変更なし

## CIでチェックできなかった項目

なし。type-check, lint, buildすべてローカルで確認済み。

## 補足

- `pnpm-lock.yaml`内にreact-native@0.83.2のゴーストバリアント（package.jsonは0.81.5を指定）が残存しているが、これはpnpmのモノレポにおけるpeer依存解決の構造的な問題（`drizzle-orm` → `@op-engineering/op-sqlite` → `react-native`のoptional peer依存チェーン）であり、クリーンインストールでも解消されない。実害はないため本PRでは対応しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)