### PR TITLE
fix: @next-lift/authenticationのtestingエクスポートを整備

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -7,7 +7,8 @@
 		"./create-auth": "./src/features/instance/create-auth.ts",
 		"./user-database-credentials": "./src/features/user-database-credentials/index.ts",
 		"./integrations/better-auth-nextjs": "./src/features/integrations/better-auth-nextjs.ts",
-		"./integrations/better-auth-react": "./src/features/integrations/better-auth-react.ts"
+		"./integrations/better-auth-react": "./src/features/integrations/better-auth-react.ts",
+		"./testing": "./src/testing/index.ts"
 	},
 	"scripts": {
 		"lint": "biome check .",

--- a/packages/authentication/src/testing/index.ts
+++ b/packages/authentication/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { factories } from "./factories/index.js";


### PR DESCRIPTION
# 概要

`@next-lift/authentication`パッケージの`testing/`ディレクトリにfactoriesとsetup.tsがあるが、外部向けの再エクスポート（`testing/index.ts`）がなく、`package.json`の`exports`にも`"./testing"`が未定義だった。

- `packages/authentication/src/testing/index.ts` を新規作成し、factoriesを再エクスポート
- `packages/authentication/package.json` の`exports`に`"./testing"`を追加
- `@next-lift/per-user-database`や`@next-lift/env`と同じパターンに統一

## この変更による影響

他パッケージから`@next-lift/authentication/testing`でテスト用ファクトリをインポートできるようになる。既存の動作への影響なし。

## CIでチェックできなかった項目

なし。`pnpm --filter @next-lift/authentication type-check`で検証済み。

## 補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)