### PR TITLE
fix: @next-lift/envから未使用の@next-lift/utilities依存を削除

### DIFF
--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -25,7 +25,6 @@
 		"vitest": "4.0.18"
 	},
 	"dependencies": {
-		"@next-lift/utilities": "workspace:*",
 		"@praha/byethrow": "0.9.0",
 		"@praha/error-factory": "1.3.1",
 		"zod": "4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,9 +254,6 @@ importers:
 
   packages/env:
     dependencies:
-      '@next-lift/utilities':
-        specifier: workspace:*
-        version: link:../utilities
       '@praha/byethrow':
         specifier: 0.9.0
         version: 0.9.0(typescript@5.9.3)


### PR DESCRIPTION
# 概要

`@next-lift/env`パッケージの`dependencies`に`@next-lift/utilities`が含まれていたが、envパッケージ内のソースコードからは使用されていなかったため削除。

## この変更による影響

不要な依存関係が解消される。envパッケージの動作への影響なし。

## CIでチェックできなかった項目

なし。型チェックとテスト（18件全パス）で検証済み。

## 補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)