### PR TITLE
fix: @next-lift/utilitiesから未使用のデフォルトエクスポートを削除

### DIFF
--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -4,7 +4,6 @@
 	"private": true,
 	"type": "module",
 	"exports": {
-		".": "./src/create-lazy-proxy.ts",
 		"./create-lazy-proxy": "./src/create-lazy-proxy.ts",
 		"./generate-id": "./src/generate-id.ts",
 		"./with-retry": "./src/with-retry.ts"


### PR DESCRIPTION
# 概要

`@next-lift/utilities`の`package.json`の`exports`から`"."`エントリを削除。`"."`は`"./create-lazy-proxy"`と重複しており、`from "@next-lift/utilities"`（サブパスなし）の利用箇所はリポジトリ内に存在しなかった。

## この変更による影響

`@next-lift/utilities`からのインポートは必ずサブパス指定（`/create-lazy-proxy`, `/generate-id`, `/with-retry`）が必要になる。既存コードはすべてサブパス指定済みのため影響なし。

## CIでチェックできなかった項目

なし。型チェックで検証済み。

## 補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)