### PR TITLE
test: generateIdのテストを追加

### DIFF
--- a/packages/utilities/src/generate-id.test.ts
+++ b/packages/utilities/src/generate-id.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { generateId } from "./generate-id";
+
+describe("generateId", () => {
+	describe("生成されるIDの形式", () => {
+		test("長さが12文字であること", () => {
+			const id = generateId();
+
+			expect(id).toHaveLength(12);
+		});
+
+		test("0-9a-zの文字のみで構成されること", () => {
+			const id = generateId();
+
+			expect(id).toMatch(/^[0-9a-z]+$/);
+		});
+	});
+
+	describe("一意性", () => {
+		test("複数回の呼び出しでそれぞれ異なるIDが生成されること", () => {
+			const ids = Array.from({ length: 100 }, () => generateId());
+			const uniqueIds = new Set(ids);
+
+			expect(uniqueIds.size).toBe(ids.length);
+		});
+	});
+});


### PR DESCRIPTION
# 概要

`@next-lift/utilities`の`generateId`（nanoidラッパー）にテストがなかったため追加。ID長12文字、使用文字種0-9a-z、一意性を検証。

## この変更による影響

テストカバレッジが向上する。既存コードへの影響なし。

## CIでチェックできなかった項目

なし。`pnpm --filter @next-lift/utilities test`で全テストパス確認済み。

## 補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)