### PR TITLE
test: createLazyProxyのテストを追加

### DIFF
--- a/packages/utilities/src/create-lazy-proxy.test.ts
+++ b/packages/utilities/src/create-lazy-proxy.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createLazyProxy } from "./create-lazy-proxy";
+
+describe("createLazyProxy", () => {
+	describe("Proxy生成時", () => {
+		const initializer = vi.fn();
+
+		beforeEach(() => {
+			initializer.mockReturnValue({ key: "value" });
+			createLazyProxy(initializer);
+		});
+
+		test("初期化関数が呼ばれないこと", () => {
+			expect(initializer).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("プロパティに初めてアクセスしたとき", () => {
+		const initializer = vi.fn();
+
+		beforeEach(() => {
+			initializer.mockReturnValue({ key: "value" });
+		});
+
+		test("初期化関数が呼ばれること", () => {
+			const proxy = createLazyProxy(initializer);
+
+			proxy.key;
+
+			expect(initializer).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("プロパティに複数回アクセスしたとき", () => {
+		const initializer = vi.fn();
+
+		beforeEach(() => {
+			initializer.mockReturnValue({ a: 1, b: 2 });
+		});
+
+		test("初期化関数が1回だけ呼ばれること", () => {
+			const proxy = createLazyProxy(initializer);
+
+			proxy.a;
+			proxy.b;
+			proxy.a;
+
+			expect(initializer).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("プロパティアクセスの委譲", () => {
+		const initializer = vi.fn();
+
+		beforeEach(() => {
+			initializer.mockReturnValue({ name: "test", count: 42 });
+		});
+
+		test("初期化されたオブジェクトのプロパティ値が返ること", () => {
+			const proxy = createLazyProxy<{ name: string; count: number }>(
+				initializer,
+			);
+
+			expect(proxy.name).toBe("test");
+			expect(proxy.count).toBe(42);
+		});
+	});
+});


### PR DESCRIPTION
# 概要

`@next-lift/utilities`の`createLazyProxy`にテストがなかったため追加。遅延初期化、キャッシュ動作、プロパティアクセスの委譲を検証。

## この変更による影響

テストカバレッジが向上する。既存コードへの影響なし。

## CIでチェックできなかった項目

なし。`pnpm --filter @next-lift/utilities test`で全テストパス確認済み。

## 補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)