### PR TITLE
fix: Document Reviewワークフローにallowed_botsを追加

### DIFF
--- a/.github/workflows/document-review.yml
+++ b/.github/workflows/document-review.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: anthropics/claude-code-action@edd85d61533cbba7b57ed0ca4af1750b1fdfd3c4 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "next-lift-merge-master"
           prompt: |
             このPRの変更内容を分析し、ドキュメント更新漏れがないかチェックしてください。
 


### PR DESCRIPTION
# 概要

Document Reviewワークフロー（claude-code-action）で、Bot（next-lift-merge-master）が作成したPRが拒否されていた問題を修正。`allowed_bots: "next-lift-merge-master"`を追加し、Document Reviewワークフロー失敗の約64%を占めるBot拒否パターンを解消する。

## この変更による影響

next-lift-merge-master BotによるPRマージ時にDocument Reviewワークフローが正常に実行されるようになる。

## CIでチェックできなかった項目

- next-lift-merge-masterが作成したPRでDocument Reviewワークフローが正常に動作すること（PRマージ後に確認）
- Claude API一時障害（パターン2、約8%）は経過観察

## 補足

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> 旧PR: #529（ブランチ名修正のため再作成）