### PR TITLE
Claude Code GitHub Appのワークフローを追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,29 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,55 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Determine branch prefix
+        id: branch
+        env:
+          LABELS: ${{ toJSON(github.event.issue.labels.*.name) }}
+        run: |
+          PREFIX="chore/claude/"
+          for label in feature bugfix improve refactor infra docs deps; do
+            if echo "$LABELS" | grep -q "\"$label\""; then
+              PREFIX="${label}/claude/"
+              break
+            fi
+          done
+          echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          branch_prefix: ${{ steps.branch.outputs.prefix }}
+
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
# 概要

IssueやPRのコメントで`@claude`とメンションすると、自動的に実装やコードレビューを行うGitHub Actionsワークフローを追加する。

PR #546 と同内容だが、ブランチ命名規則に準拠したブランチ名で作り直した。

追加ファイル:
- `.github/workflows/claude.yml` — `@claude`メンション対応ワークフロー
- `.github/workflows/claude-code-review.yml` — PR自動コードレビューワークフロー

Issueのラベル（`feature`, `bugfix`, `improve`等）に応じて`branch_prefix`を動的に決定し、ブランチ命名規則に準拠させる（ラベルなしの場合は`chore/claude/`がデフォルト）。

## この変更による影響

- IssueやPRコメントで`@claude`メンションが使えるようになる
- PRが作成されると自動でコードレビューが実行される

## CIでチェックできなかった項目

- mainマージ後に`@claude`メンションで実際に動作するかの確認
- ラベルに応じた正しいブランチプレフィックスの生成

## 補足

- PR #546 はブランチ名違反のためクローズ予定