### PR TITLE
PR作成完了時に振り返りを促すPostToolUseフックを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,15 @@
             "command": "jq -r '.tool_input.file_path // empty' | grep -E '\\.(ts|tsx|js|jsx)$' | head -1 | xargs -I {} pnpm biome check --write {}"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | grep -q 'gh pr create' && echo 'PR\u4f5c\u6210\u304c\u5b8c\u4e86\u3057\u307e\u3057\u305f\u3002\u3053\u306e\u4f5c\u696d\u3092\u901a\u3058\u3066\u5b66\u3073\u3084\u6539\u5584\u70b9\u304c\u3042\u308c\u3070\u3001/retrospective \u3067\u632f\u308a\u8fd4\u308a\u3092\u5b9f\u65bd\u3057\u3066\u304f\u3060\u3055\u3044\u3002' || true"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
# 概要

close #558

retrospectiveスキルが定義されているが使用されていない問題を解決するため、PostToolUseフックでPR作成を検知し、振り返りの実施を自動提案する仕組みを追加する。

## この変更による影響

- PR作成コマンド実行後に `/retrospective` の実施を促すメッセージが表示されるようになる
- PR作成以外のBashコマンドには影響しない（`|| true` で無出力）

## CIでチェックできなかった項目

- 実際のPR作成時にフックが正しく動作し、メッセージが表示されること

## 補足

- PostToolUse（ツール実行後）のフックのため、PR作成をブロックすることはない
- コマンドの動作原理: `jq` でBashコマンドを取得 → `grep -q` でPR作成か判定 → マッチ時のみメッセージ出力