### PR TITLE
fix: document-reviewのPRコメント投稿を修正

### DIFF
--- a/.github/workflows/document-review.yml
+++ b/.github/workflows/document-review.yml
@@ -29,6 +29,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "next-lift-merge-master"
           use_sticky_comment: true
+          track_progress: true
           prompt: |
             このPRの変更内容を分析し、ドキュメント更新漏れがないかチェックしてください。
 

--- a/docs/architecture-decision-record/022-claude-code-action-security.md
+++ b/docs/architecture-decision-record/022-claude-code-action-security.md
@@ -23,6 +23,9 @@ PR #564のドキュメントレビューワークフロー（`document-review.ym
   - Bashが必要な場合: 具体的なコマンドプレフィックスで制限する（例: `Bash(git diff:*)`）
 - **`--allowedTools Bash`（無制限Bash）は使用しない**
 - PRコメント投稿はclaude-code-actionの組み込み機能（`use_sticky_comment`）を使用する
+- `prompt`を指定するagentモードワークフローでは`track_progress: true`を併用する
+  - `use_sticky_comment: true`のみではagent modeでコメントが投稿されない（claude-code-actionの制限: [#621](https://github.com/anthropics/claude-code-action/issues/621)）
+  - `track_progress: true`によりtag modeが強制され、tracking commentの自動投稿が有効になる
 - プロンプト内でシェルコマンドの実行を指示しない
 
 ### 2. インタラクティブワークフロー（@claudeメンション）


### PR DESCRIPTION
# 概要

`document-review.yml`に`track_progress: true`を追加し、agent modeでもPRコメントが投稿されるよう修正。ADR-022にこの制限事項と対処法を追記。

PR #568でdocument-reviewワークフローが正常完了したにもかかわらず、PRコメントが投稿されなかった。claude-code-actionの制限により、`prompt`パラメータが存在する`pull_request`イベントはagent modeとして処理され、`use_sticky_comment`が無視される（[claude-code-action #621](https://github.com/anthropics/claude-code-action/issues/621)）。

`track_progress: true`を指定することでtag modeが強制され、tracking commentの自動投稿が有効になる。

Closes #569

## この変更による影響

- document-reviewワークフローがPRにレビューコメントを投稿するようになる
- 今後`prompt`を指定する新しいワークフローを追加する際のガイドラインが明確化される

## CIでチェックできなかった項目

- このPRでdocument-reviewワークフローが実行され、PRコメントが投稿されることの確認
- ワークフローログで`allowedTools`制限が有効であることの確認
- `use_sticky_comment: true`と`track_progress: true`の併用でコメントが重複しないことの確認

## 補足

`use_sticky_comment: true`と`track_progress: true`の併用でコメントが重複する可能性がある。重複が発生した場合は`use_sticky_comment`を削除し`track_progress: true`のみとする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)