### PR TITLE
fix: document-reviewプロンプトにツール制約を明示

### DIFF
--- a/.github/workflows/document-review.yml
+++ b/.github/workflows/document-review.yml
@@ -60,6 +60,7 @@ jobs:
 
             分析結果をそのまま最終レスポンスとして返してください。
             外部コマンドの実行やPRへのコメント投稿は不要です。
+            利用可能なツールはRead, Glob, Grepのみです。Bashコマンドやファイル編集は行わないでください。
           claude_args: |
             --max-turns 10
             --allowedTools "Read,Glob,Grep"


### PR DESCRIPTION
# 概要

`track_progress: true`により`--allowedTools`制限が実質無効化され、ClaudeがBashを使おうとしてpermission deniedを繰り返し`error_max_turns`となる問題への対処。プロンプトにRead/Glob/Grepのみ使用する旨を明示し、Bashコマンドの使用を抑止する。

close #569

## この変更による影響

document-reviewワークフローの安定性が向上する。ユーザーへの影響はない。

## CIでチェックできなかった項目

- [ ] PR #572をsynchronize（空コミットまたはrebase）してdocument-reviewワークフローが正常完了しPRコメントが投稿されることを確認

## 補足

claude-code-actionの既知バグ（[anthropics/claude-code-action#860](https://github.com/anthropics/claude-code-action/issues/860)）が修正されるまでの暫定対処。

🤖 Generated with [Claude Code](https://claude.com/claude-code)