### PR TITLE
fix: Claude Code ActionのPR作成権限を復元する

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/docs/architecture-decision-record/022-claude-code-action-security.md
+++ b/docs/architecture-decision-record/022-claude-code-action-security.md
@@ -32,6 +32,10 @@ PR #564のドキュメントレビューワークフロー（`document-review.ym
 
 - デフォルトのツール構成を使用する
 - `allowedTools`の追加指定は原則として行わない
+- `permissions`は`contents: write`、`pull-requests: write`、`issues: write`を設定する
+  - ブランチのpushとPR作成にはwrite権限が必要
+  - Claude Code Actionはリポジトリのwrite accessを持つユーザーの`@claude`メンションにのみ反応するため、権限昇格のリスクは限定的
+- 自動ワークフロー（`document-review.yml`等）はread-only権限を維持する
 
 ### 3. 権限設定
 


### PR DESCRIPTION
# 概要

close #570

セキュリティ強化(#567)で`claude.yml`の権限を`read`に制限した結果、Claude Code Actionがブランチのpush・PR作成ができなくなった問題を修正する。

## この変更による影響

- Claude Code Actionの`@claude`メンションによるインタラクティブワークフローで、ブランチのpush・PR作成が再び可能になる
- 自動ワークフロー（`document-review.yml`等）の権限はread-onlyのまま変更なし

## CIでチェックできなかった項目

- マージ後、Issueで`@claude`メンションしてブランチpush・PR作成が動作することを確認する

## 補足

- ADR-022にwrite権限の根拠を追記済み
- Claude Code Actionはリポジトリのwrite accessを持つユーザーの`@claude`メンションにのみ反応するため、権限昇格のリスクは限定的