### PR TITLE
ci: ドキュメントのみの変更PRでビルド・リント・型チェックをスキップする

### DIFF
--- a/.github/workflows/pr-push-check.yml
+++ b/.github/workflows/pr-push-check.yml
@@ -5,8 +5,34 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.check.outputs.code }}
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check for code changes
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          code_changes="false"
+          while IFS= read -r file; do
+            case "$file" in
+              docs/*|*.md|.claude/*) ;;
+              *) code_changes="true"; break ;;
+            esac
+          done <<< "$files"
+          echo "code=$code_changes" >> "$GITHUB_OUTPUT"
+
   build-and-type-check:
     name: Build and Type check
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -38,6 +64,8 @@ jobs:
 
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
# 概要

ドキュメントのみの変更（`docs/**`, `*.md`, `.claude/**`）でPRを作成した際に、ビルド・型チェック・リントなど重いCIジョブをスキップするようにした。

close #579

## この変更による影響

- ドキュメントのみの変更PRでCIの待ち時間が大幅に短縮される
- コード変更を含むPRは従来通りすべてのジョブが実行される
- Required Status Checksは"Skipped"状態で満たされるため、マージブロックは発生しない

## 仕組み

`pr-push-check.yml`に`changes`ジョブを追加し、GitHub APIでPRの変更ファイル一覧を取得。以下のパターン**のみ**の変更の場合、`build-and-type-check`と`lint`をスキップする:

| パターン | 例 |
|---------|---|
| `docs/**` | `docs/project/overview.md` |
| `*.md` | `README.md`, `CLAUDE.md` |
| `.claude/**` | `.claude/rules/testing.md` |

## CIでチェックできなかった項目

- ドキュメントのみ変更のPRでジョブがスキップされること
- スキップ時にRequired Status Checksが満たされマージ可能であること
- コード変更を含むPRで従来通り全ジョブが実行されること

## 補足

- `dorny/paths-filter`はNode20非推奨問題があるため、`gh api`で直接変更ファイルを取得する方式を採用
- `setup-preview.yml`は既に`with-preview`ラベルによるゲートがあるため対象外
- `merge-master.yml`はワークフロー自体は実行されるため`workflow_run`トリガーへの影響なし