### PR TITLE
fix: document-reviewのallowedTools制限が無効化される問題を修正

### DIFF
--- a/.github/workflows/document-review.yml
+++ b/.github/workflows/document-review.yml
@@ -32,7 +32,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "next-lift-merge-master"
           use_sticky_comment: true
-          track_progress: true
           prompt: |
             このPRの変更内容を分析し、ドキュメント更新漏れがないかチェックしてください。
             以下にレビューに必要なコンテキストをすべて提供しています。ツール呼び出しは原則不要です。


### PR DESCRIPTION
# 概要

`track_progress: true` を削除して `--allowedTools "Read,Glob,Grep"` の制限を正しく機能させる。

claude-code-actionの[既知バグ](https://github.com/anthropics/claude-code-action/issues/860)により、`track_progress: true` と `--allowedTools` を併用するとツール制限が無効化され、不要なツール呼び出しで `--max-turns 5` の上限を超過しCIが失敗していた（#598）。

## この変更による影響

Document Reviewワークフローの安定性が向上する。`track_progress` による進捗表示は失われるが、レビュー結果はsticky commentとして投稿されるため実用上の影響はない。

## CIでチェックできなかった項目

- Document Reviewワークフローが `error_max_turns` で失敗しないこと

## 補足

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)