### PR TITLE
refactor(authentication): ファクトリのID生成をgenerateIdに統一

### DIFF
--- a/packages/authentication/src/testing/factories/account-factory.ts
+++ b/packages/authentication/src/testing/factories/account-factory.ts
@@ -1,3 +1,4 @@
+import { generateId } from "@next-lift/utilities/generate-id";
 import { defineFactory } from "@praha/drizzle-factory";
 import { schema } from "../../database-schemas";
 import { userFactory } from "./user-factory";
@@ -6,7 +7,7 @@ export const accountFactory = defineFactory({
 	schema,
 	table: "account",
 	resolver: ({ sequence, use }) => ({
-		id: `account-${sequence}`,
+		id: generateId(),
 		userId: () =>
 			use(userFactory)
 				.create()
@@ -25,7 +26,7 @@ export const accountFactory = defineFactory({
 	}),
 	traits: {
 		github: ({ sequence, use }) => ({
-			id: `account-${sequence}`,
+			id: generateId(),
 			userId: () =>
 				use(userFactory)
 					.create()

--- a/packages/authentication/src/testing/factories/per-user-database-factory.ts
+++ b/packages/authentication/src/testing/factories/per-user-database-factory.ts
@@ -1,3 +1,4 @@
+import { generateId } from "@next-lift/utilities/generate-id";
 import { defineFactory } from "@praha/drizzle-factory";
 import { schema } from "../../database-schemas";
 import { userFactory } from "./user-factory";
@@ -6,7 +7,7 @@ export const perUserDatabaseFactory = defineFactory({
 	schema,
 	table: "perUserDatabase",
 	resolver: ({ sequence, use }) => ({
-		id: `per-user-db-${sequence}`,
+		id: generateId(),
 		userId: () =>
 			use(userFactory)
 				.create()

--- a/packages/authentication/src/testing/factories/session-factory.ts
+++ b/packages/authentication/src/testing/factories/session-factory.ts
@@ -1,3 +1,4 @@
+import { generateId } from "@next-lift/utilities/generate-id";
 import { defineFactory } from "@praha/drizzle-factory";
 import { schema } from "../../database-schemas";
 import { userFactory } from "./user-factory";
@@ -6,7 +7,7 @@ export const sessionFactory = defineFactory({
 	schema,
 	table: "session",
 	resolver: ({ sequence, use }) => ({
-		id: `session-${sequence}`,
+		id: generateId(),
 		userId: () =>
 			use(userFactory)
 				.create()

--- a/packages/authentication/src/testing/factories/user-factory.ts
+++ b/packages/authentication/src/testing/factories/user-factory.ts
@@ -1,3 +1,4 @@
+import { generateId } from "@next-lift/utilities/generate-id";
 import { defineFactory } from "@praha/drizzle-factory";
 import { schema } from "../../database-schemas";
 
@@ -5,7 +6,7 @@ export const userFactory = defineFactory({
 	schema,
 	table: "user",
 	resolver: ({ sequence }) => ({
-		id: `user-${sequence}`,
+		id: generateId(),
 		name: `Test User ${sequence}`,
 		email: `user${sequence}@example.com`,
 		emailVerified: false,
@@ -15,7 +16,7 @@ export const userFactory = defineFactory({
 	}),
 	traits: {
 		verified: ({ sequence }) => ({
-			id: `user-${sequence}`,
+			id: generateId(),
 			name: `Test User ${sequence}`,
 			email: `user${sequence}@example.com`,
 			emailVerified: true,


### PR DESCRIPTION
# 概要

`packages/authentication/src/testing/factories/*` の4ファクトリ（user / account / session / per-user-database）で、テストデータのIDを sequence ベース（`user-1` 等）から `generateId()` に変更する。

ADR-025（ドメインIDは `generateId` を使う決定）との一貫性を取り、ID形式に依存するテストの偽陰性リスクを構造的に防ぐことが目的。

## この変更による影響

- **既存テストへの影響なし**: コードベース全体を grep した結果、IDの値そのものに依存する \`expect(...id).toBe/toEqual/toMatch(...)\` 系のテストは0件
- **本番との形式統一**: 本番では `generateId()`（nanoid 36進12文字）を使っているのに対し、ファクトリは `${prefix}-${sequence}` 形式という不整合があった。本変更で形式を揃える
- **テスト失敗時のメッセージ**: ファクトリ生成IDをそのまま読んでも文脈は分からないが、テストコード上は変数名で参照するため実用上は影響軽微

## CIでチェックできなかった項目

- 特になし（既存テストはすべて通過、型・lint も問題なし）

## 補足

- 同様の修正を `packages/per-user-database/src/testing/factories/*` には PR #660 内で実施済み（factories新規追加と合わせて最初から `generateId` で揃える形）
- 認証側はすでにmainに存在する既存コードの振る舞い変更のため、レビュー単位を分けて本PRとして独立させる
- 関連: ADR-025 https://github.com/gn-t-k/next-lift/blob/main/docs/architecture-decision-record/025-domain-id-generation-strategy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)