### PR TITLE
feat(per-user-database): factoriesをtestingエクスポートに追加

### DIFF
--- a/packages/per-user-database/package.json
+++ b/packages/per-user-database/package.json
@@ -25,16 +25,16 @@
 		"@libsql/client": "0.17.2",
 		"@next-lift/env": "workspace:*",
 		"@next-lift/turso": "workspace:*",
+		"@next-lift/utilities": "workspace:*",
 		"@praha/byethrow": "0.9.0",
 		"@praha/diva": "1.0.2",
+		"@praha/drizzle-factory": "1.4.2",
 		"@praha/error-factory": "1.4.1",
 		"drizzle-orm": "0.45.2",
 		"zod": "4.3.6"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.6",
-		"@next-lift/utilities": "workspace:*",
-		"@praha/drizzle-factory": "1.4.2",
 		"@tsconfig/strictest": "2.0.8",
 		"@types/node": "24.12.2",
 		"drizzle-kit": "0.31.10",

--- a/packages/per-user-database/src/testing/index.ts
+++ b/packages/per-user-database/src/testing/index.ts
@@ -16,4 +16,5 @@ export {
 	mockCreateTursoPerUserDatabaseError,
 	mockCreateTursoPerUserDatabaseOk,
 } from "../features/create-database/create-turso-per-user-database.mock";
+export { factories } from "./factories";
 export { mockedPerUserDatabase } from "./mocked-per-user-database";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,12 +297,18 @@ importers:
       '@next-lift/turso':
         specifier: workspace:*
         version: link:../turso
+      '@next-lift/utilities':
+        specifier: workspace:*
+        version: link:../utilities
       '@praha/byethrow':
         specifier: 0.9.0
         version: 0.9.0(typescript@5.9.3)
       '@praha/diva':
         specifier: 1.0.2
         version: 1.0.2
+      '@praha/drizzle-factory':
+        specifier: 1.4.2
+        version: 1.4.2(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@op-engineering/op-sqlite@15.2.11(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(kysely@0.28.8))
       '@praha/error-factory':
         specifier: 1.4.1
         version: 1.4.1
@@ -316,12 +322,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.3.6
         version: 2.3.6
-      '@next-lift/utilities':
-        specifier: workspace:*
-        version: link:../utilities
-      '@praha/drizzle-factory':
-        specifier: 1.4.2
-        version: 1.4.2(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@op-engineering/op-sqlite@15.2.11(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(kysely@0.28.8))
       '@tsconfig/strictest':
         specifier: 2.0.8
         version: 2.0.8
@@ -9953,7 +9953,7 @@ snapshots:
   '@react-native/codegen@0.83.2(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       glob: 7.2.3
       hermes-parser: 0.32.0
       invariant: 2.2.4


### PR DESCRIPTION
# 概要

`@next-lift/per-user-database/testing` から `factories` をエクスポート可能にする。

per-user-database はスキーマを公開しているため、アプリ側で DB を直接クエリするコード（例: `db.select().from(programs)`）をテストする際に seed データ生成手段が必要。authentication パッケージとは異なり、per-user-database は外部からスキーマを利用される前提のため、ファクトリも公開APIとして提供する。

#660 のレビュー対応として認識した論点を、別PRに切り出したもの（旧 #665 はブランチ名規約違反のため作り直し）。

## この変更による影響

- アプリ側のテストで以下のパターンが書けるようになる:
  ```ts
  import { factories, mockedPerUserDatabase } from "@next-lift/per-user-database/testing";
  const program = await factories.programs(mockedPerUserDatabase).create({ name: "..." });
  ```
- `testing` パスが公開APIとして factories まで含むことになるため、その依存である `@next-lift/utilities` と `@praha/drizzle-factory` を devDependencies → dependencies に昇格

## CIでチェックできなかった項目

- 特になし（既存テストは全てパス、型・lint も問題なし）

## 補足

- authentication パッケージは DB 自体が better-auth の内部実装であり外部から DB を直接利用しない設計のため、factories は引き続き非公開（packages/authentication のスキーマは export されていない）
- 関連: ADR-005 (Per-User Database Architecture)、 #660 (Per-User Database スキーマ実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)