### PR TITLE
chore(biome): useConsistentArrayType を有効化

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -55,6 +55,10 @@
 				"noSecrets": "off"
 			},
 			"style": {
+				"useConsistentArrayType": {
+					"level": "warn",
+					"options": { "syntax": "shorthand" }
+				},
 				"useObjectSpread": "warn"
 			},
 			"suspicious": {


### PR DESCRIPTION
# 概要

Biome の `style/useConsistentArrayType` ルールを `shorthand` 設定で warn レベル有効化し、配列型を `Array<T>` ではなく `T[]` で書く方針を lint で強制する。

## この変更による影響

- 開発者: 配列型を `Array<T>` で書いていると lint で警告される。autofix で `T[]` 表記に変換可能
- アプリケーション利用者: 影響なし（コーディングスタイルのみの変更）

なお、`Array<{ id: string; ... }>` のように内部が複雑な型リテラルの場合は本ルールが発火しない仕様。複雑な要素を含む配列は名前付き型に切り出してから配列化するのが推奨される。

## CIでチェックできなかった項目

なし（lint ルールの追加のみで、既存コードに違反はない）

## 補足

`useShorthandArrayType` は Biome 2.0 で削除されており、後継の `useConsistentArrayType` を使用している（[公式ドキュメント](https://biomejs.dev/linter/rules/use-consistent-array-type/)）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)