### PR TITLE
feat(react-components): プリミティブにストーリーを追加

### DIFF
--- a/packages/react-components/src/primitive/error-alert.stories.tsx
+++ b/packages/react-components/src/primitive/error-alert.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ErrorBoundary } from "react-error-boundary";
+import { ErrorAlert } from "./error-alert";
+
+const meta = {
+	title: "UI/ErrorAlert",
+	component: ErrorAlert,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+} satisfies Meta<typeof ErrorAlert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		children: "エラーが発生しました。",
+	},
+};
+
+export const LongMessage: Story = {
+	args: {
+		children:
+			"通信エラーが発生しました。ネットワーク接続を確認した上で、しばらく経ってから再度お試しください。問題が解決しない場合はサポートまでお問い合わせください。",
+	},
+};
+
+const ThrowingComponent = () => {
+	throw new Error("意図的に発生させたエラー");
+};
+
+export const AsErrorBoundaryFallback: Story = {
+	args: { children: null },
+	render: () => (
+		<ErrorBoundary
+			fallback={<ErrorAlert>データの取得に失敗しました。</ErrorAlert>}
+		>
+			<ThrowingComponent />
+		</ErrorBoundary>
+	),
+};

--- a/packages/react-components/src/primitive/gym-context.stories.tsx
+++ b/packages/react-components/src/primitive/gym-context.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { FC } from "react";
+import { GymContext } from "./gym-context";
+
+const DensitySample: FC = () => (
+	<div className="space-y-1 rounded-md border border-border p-density-card">
+		<div className="text-density-label text-muted-fg">重量</div>
+		<div className="font-semibold text-density-value">120 kg × 5</div>
+	</div>
+);
+
+const meta = {
+	title: "UI/GymContext",
+	component: GymContext,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+} satisfies Meta<typeof GymContext>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InsideGym: Story = {
+	args: { children: null },
+	render: () => (
+		<GymContext>
+			<DensitySample />
+		</GymContext>
+	),
+};
+
+export const OutsideGym: Story = {
+	args: { children: null },
+	render: () => <DensitySample />,
+};
+
+export const SideBySide: Story = {
+	args: { children: null },
+	render: () => (
+		<div className="flex gap-6">
+			<div className="space-y-2">
+				<p className="font-semibold">ジム外（Compact）</p>
+				<DensitySample />
+			</div>
+			<GymContext className="space-y-2">
+				<p className="font-semibold">ジム内（Comfortable）</p>
+				<DensitySample />
+			</GymContext>
+		</div>
+	),
+};

--- a/packages/react-components/src/primitive/link.stories.tsx
+++ b/packages/react-components/src/primitive/link.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Link } from "./link";
+
+const meta = {
+	title: "UI/Link",
+	component: Link,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+} satisfies Meta<typeof Link>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		href: "/programs",
+		children: "プログラム一覧",
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		href: "/programs",
+		isDisabled: true,
+		children: "無効なリンク",
+	},
+};
+
+export const InText: Story = {
+	args: { children: null },
+	render: () => (
+		<p>
+			詳細は<Link href="/help">ヘルプページ</Link>
+			をご確認ください。
+		</p>
+	),
+};

--- a/packages/react-components/src/primitive/page-heading.stories.tsx
+++ b/packages/react-components/src/primitive/page-heading.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PageHeading } from "./page-heading";
+
+const meta = {
+	title: "UI/PageHeading",
+	component: PageHeading,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+	argTypes: {
+		as: {
+			control: "select",
+			options: ["h1", "h2", "h3", "h4", "h5", "h6"],
+		},
+	},
+} satisfies Meta<typeof PageHeading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const H1: Story = {
+	args: {
+		as: "h1",
+		children: "プログラム",
+	},
+};
+
+export const H2: Story = {
+	args: {
+		as: "h2",
+		children: "セクションタイトル",
+	},
+};
+
+export const AllLevels: Story = {
+	args: { as: "h1", children: null },
+	render: () => (
+		<div className="flex flex-col gap-4">
+			<PageHeading as="h1">h1: ページタイトル</PageHeading>
+			<PageHeading as="h2">h2: セクションタイトル</PageHeading>
+			<PageHeading as="h3">h3: サブセクション</PageHeading>
+			<PageHeading as="h4">h4: 小見出し</PageHeading>
+			<PageHeading as="h5">h5: より小さい見出し</PageHeading>
+			<PageHeading as="h6">h6: 最小の見出し</PageHeading>
+		</div>
+	),
+};

--- a/packages/react-components/src/primitive/page-section.stories.tsx
+++ b/packages/react-components/src/primitive/page-section.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PageHeading } from "./page-heading";
+import { PageSection } from "./page-section";
+
+const meta = {
+	title: "UI/PageSection",
+	component: PageSection,
+	parameters: {
+		layout: "fullscreen",
+	},
+	tags: ["autodocs"],
+	argTypes: {
+		as: {
+			control: "select",
+			options: ["main", "section"],
+		},
+		width: {
+			control: "select",
+			options: ["narrow", "wide"],
+		},
+	},
+} satisfies Meta<typeof PageSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Narrow: Story = {
+	args: {
+		as: "main",
+		width: "narrow",
+		children: (
+			<>
+				<PageHeading as="h1">narrow ページ</PageHeading>
+				<p>
+					max-w-2xl で表示される。フォームや記事など読みやすさ重視のページ向け。
+				</p>
+			</>
+		),
+	},
+};
+
+export const Wide: Story = {
+	args: {
+		as: "main",
+		width: "wide",
+		children: (
+			<>
+				<PageHeading as="h1">wide ページ</PageHeading>
+				<p>
+					max-w-screen-xl
+					で表示される。一覧画面やダッシュボードなど情報量の多いページ向け。
+				</p>
+			</>
+		),
+	},
+};
+
+export const NestedSection: Story = {
+	args: { children: null },
+	render: () => (
+		<PageSection as="main" width="wide">
+			<PageHeading as="h1">メインタイトル</PageHeading>
+			<p>main コンテナ。配下に section をネストできる。</p>
+			<PageSection as="section" width="narrow">
+				<PageHeading as="h2">サブセクション</PageHeading>
+				<p>section コンテナとして使う例。</p>
+			</PageSection>
+		</PageSection>
+	),
+};


### PR DESCRIPTION
# 概要

`ErrorAlert` / `GymContext` / `Link` / `PageHeading` / `PageSection` の Storybook を新設する。

後続でプリミティブを `primitive/{name}/` 形式のフォルダコロケーション構造に揃える計画があり、その下準備として「各プリミティブのバレルが本体 + ストーリーのセットで意味を持つ」状態に揃える。

## この変更による影響

- 新規ファイルの追加のみで、既存コンポーネントの実装・export には変更なし
- `apps/web` 等の利用側に影響なし
- Storybook を見る開発者は新たに 5 種類のストーリーを確認できる

## CIでチェックできなかった項目

- 各ストーリーの表示崩れ・レイアウト確認（`pnpm --filter @next-lift/react-components exec storybook dev -p 6007` で目視確認をお願いします）
- `GymContext` の `SideBySide` ストーリーで密度トークン（`text-density-label` / `text-density-value` / `p-density-card`）がジム内/外で切り替わって見えること
- `ErrorAlert` の `AsErrorBoundaryFallback` ストーリーで意図的にスローしたエラーがアラートで表示されること

## 補足

`Dialog` は `primitive/index.ts` から公開されておらず Modal の内部実装としてのみ利用されているため、後続 PR で `modal/` 配下にコロケーションする方針。本 PR ではストーリー対象外。