### PR TITLE
infra(worktree): Storybookポート競合と chrome-devtools MCP プロファイル衝突を解消

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest", "--isolated=true"]
+    }
+  }
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -52,7 +52,7 @@
 	"scripts": {
 		"lint": "biome check .",
 		"type-check": "tsc --noEmit",
-		"storybook": "storybook dev -p 6006",
+		"storybook": "storybook dev --ci -p ${STORYBOOK_PORT:-6006} --exact-port",
 		"build-storybook": "storybook build",
 		"ui:fetch": "pnpm dlx shadcn@latest add"
 	}


### PR DESCRIPTION
# 概要

worktree 並行運用時に発生する 2 つの衝突を解消する。

- Storybook のポート競合: 親リポと worktree 間で `localhost:6006` が衝突し、対話プロンプトでバックグラウンド起動が止まる
- Chrome DevTools MCP のプロファイル衝突: `~/.cache/chrome-devtools-mcp/chrome-profile` を取り合うため、worktree 側で別 Chrome を起動できない

worktree は使い捨て前提なので、最も軽量な分離手段で十分という判断。

close #678

## この変更による影響

- 開発者: `pnpm storybook` の起動オプションが変わる。デフォルトポート（6006）で起動する挙動は維持。`STORYBOOK_PORT` env で worktree ごとにポートを切り替えられる
- 既存ポートが埋まっている状態で `STORYBOOK_PORT` 未指定だと即エラー終了するようになる（`--exact-port` の fail-fast）
- `.mcp.json` をプロジェクトルートに新設したため、初回 Claude Code セッション起動時に MCP 承認プロンプトが出る可能性あり

## CIでチェックできなかった項目

- 親リポで Storybook を 6006 で起動した状態で worktree 側から `STORYBOOK_PORT=6106 pnpm storybook` を叩き、対話プロンプトなしで 6106 で起動できること
- 6006 が埋まった状態で env 未指定の `pnpm storybook` が即エラー終了すること
- 親 Claude Code が chrome-devtools MCP を握ったまま worktree 側で `mcp__chrome-devtools__new_page` がエラーなく開けること

## 補足

- 関連: #679（.env.local 継承・Turso トークン）/ #680（worktree-tips skill）
- 永続プロファイルが必要なユースケースが出た場合は `--isolated=true` を `--user-data-dir` ベースの切替に置き換える

🤖 Generated with [Claude Code](https://claude.com/claude-code)