### PR TITLE
infra(worktree): .env コピースクリプトと Turso トークン運用ガイドを追加

### DIFF
--- a/.claude/scripts/copy-worktree-env.sh
+++ b/.claude/scripts/copy-worktree-env.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# worktree 用に親リポジトリの env ファイルを現在のworktreeへコピーする。
+#
+# 使い方:
+#   bash .claude/scripts/copy-worktree-env.sh
+#
+# 動作:
+#   1. `git rev-parse --git-common-dir` で親リポの .git を解決
+#   2. 親リポの worktree ルート配下から、gitignore 対象の env ファイル
+#      (.env / .env.local / .env.*.local) を列挙
+#   3. 同じ相対パスで現在の worktree にコピー
+#
+# 安全策:
+#   - 親リポと現在のworktreeが同一ディレクトリの場合は何もしない
+#   - 上書き前に既存ファイルとの差分有無を表示し、差分がある場合のみコピー
+
+set -euo pipefail
+
+current_root=$(git rev-parse --show-toplevel)
+common_dir=$(git rev-parse --git-common-dir)
+parent_root=$(cd "$(dirname "$common_dir")" && pwd)
+
+if [ "$current_root" = "$parent_root" ]; then
+  echo "現在のディレクトリは親リポジトリです。worktree でのみ実行してください。" >&2
+  exit 1
+fi
+
+echo "親リポジトリ: $parent_root"
+echo "worktree   : $current_root"
+echo
+
+env_patterns=(
+  ".env"
+  ".env.local"
+  ".env.development.local"
+  ".env.test.local"
+  ".env.production.local"
+)
+
+copied=0
+skipped=0
+
+while IFS= read -r -d '' file; do
+  rel="${file#${parent_root}/}"
+  dest="${current_root}/${rel}"
+
+  for pattern in "${env_patterns[@]}"; do
+    if [ "$(basename "$file")" = "$pattern" ]; then
+      mkdir -p "$(dirname "$dest")"
+      if [ -f "$dest" ] && cmp -s "$file" "$dest"; then
+        echo "skip: $rel (一致)"
+        skipped=$((skipped + 1))
+      else
+        cp "$file" "$dest"
+        echo "copy: $rel"
+        copied=$((copied + 1))
+      fi
+      break
+    fi
+  done
+done < <(find "$parent_root" \
+  -type d \( -name node_modules -o -name .git -o -name .next -o -name .turbo -o -name dist -o -name build -o -name .vercel \) -prune \
+  -o -type f \( -name ".env" -o -name ".env.local" -o -name ".env.*.local" \) -print0)
+
+echo
+echo "完了: コピー ${copied} 件 / スキップ ${skipped} 件"

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ packages/
 
 - [開発計画](docs/project/overview.md)
 - [ADR](docs/architecture-decision-record/overview.md)
+- [worktree 運用ガイド](docs/development/worktree.md)

--- a/docs/development/worktree.md
+++ b/docs/development/worktree.md
@@ -1,0 +1,55 @@
+# worktree 運用ガイド
+
+`git worktree` で Claude Code セッションを並行運用する際の手順とルール。
+
+## 前提
+
+- worktree は使い捨て前提で作成・削除する
+- 親リポジトリ（`/Users/.../next-lift`）と worktree（`.claude/worktrees/<name>/` など）は同一の `.git` を共有するが、作業ツリーは独立する
+- `node_modules`、`.env`、`.env.local`、`.next/`、`.turbo/` などはディレクトリごとに独立する
+
+## env ファイルの引き継ぎ
+
+`.env` / `.env.local` / `.env.*.local` は gitignore 対象のため `git worktree add` では持ち込まれない。worktree 作成直後に親リポからコピーする。
+
+```sh
+# worktree のルートで実行
+bash .claude/scripts/copy-worktree-env.sh
+```
+
+スクリプトの動作:
+
+- 親リポの worktree ルート配下を再帰的に走査し、`.env` `.env.local` `.env.*.local` を抽出
+- 同じ相対パスで現在の worktree へコピー（`apps/web/.env` → `<worktree>/apps/web/.env` など）
+- 既存ファイルと内容が一致する場合はスキップ、差分があれば上書き
+- `node_modules` `.git` `.next` `.turbo` `dist` `build` `.vercel` は走査対象外
+
+セキュリティ上の理由で、コピーは worktree から手動実行する明示的な仕組みにしている（自動 SessionStart hook で常時上書きはしない）。
+
+## Turso トークン管理
+
+worktree 並行運用で起こりやすい事故:
+
+- 1 つの worktree のエージェントが Turso トークンを revoke / rotate した瞬間、他方の worktree が落ちる
+- 古い長命トークンが手動コピーで複数 worktree に残り続ける
+- 本番テナント DB を worktree から誤って叩く
+
+### ルール
+
+1. **長命トークンを `.env` に直書きしない**: `turso db tokens create --expiration 24h` のように短命化する
+2. **本番テナントの Turso group には worktree から接続しない**: マイグレーションや本番データ操作は親リポからのみ実行
+3. **トークンを rotate するときは事前に他 worktree の状況を確認する**: 並行作業中の他セッションを落とさない
+
+短命トークンの取得例:
+
+```sh
+# 24時間で失効するトークンを取得
+turso db tokens create <db-name> --expiration 24h
+```
+
+将来的に worktree ごとに専用 group / db を切り出す運用も検討対象だが、コストとのトレードオフのため現時点では採用しない。
+
+## 関連
+
+- #678: Storybook ポート / chrome-devtools MCP プロファイル衝突対策
+- #680: worktree 並列作業の罠まとめ skill（予定）

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"lint": "turbo lint",
 		"type-check": "turbo type-check",
 		"test": "turbo test",
-		"clean": "turbo clean"
+		"clean": "turbo clean",
+		"worktree:copy-env": "bash .claude/scripts/copy-worktree-env.sh"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.6",


### PR DESCRIPTION
# 概要

worktree 並行運用時に発生する 2 つの事故を防ぐ。

- `.env` / `.env.local` が `git worktree add` で持ち込まれず、worktree 側が古い秘匿情報で動作する
- 1 つの worktree のエージェントが Turso トークンを revoke / rotate した瞬間に他方が落ちる、本番テナントを誤って叩く

close #679

## 変更内容

- `.claude/scripts/copy-worktree-env.sh` を新設
  - `git rev-parse --git-common-dir` で親リポを解決し、`.env` `.env.local` `.env.*.local` を相対パスを保ったままコピー
  - `cmp` で差分判定し、差分があるときだけ上書き（一致するファイルはスキップ表示）
  - `node_modules` `.git` `.next` `.turbo` `dist` `build` `.vercel` は走査対象外
  - 親リポ自体で実行するとエラー終了
- `pnpm worktree:copy-env` でラップ
- `docs/development/worktree.md` を新設し、運用ルールを明文化
  - env コピー手順
  - Turso トークン短命化（`turso db tokens create --expiration 24h`）
  - 本番テナントへの worktree 直接接続禁止
- README に運用ガイドへのリンクを追加

## この変更による影響

- 開発者: worktree 作成後に `pnpm worktree:copy-env` を実行する手順が追加される
- worktree でない場所で実行した場合は明示的にエラー終了する（誤用防止）
- 自動 SessionStart hook での常時上書きは敢えて採用していない（古いトークンで上書きされる事故を避ける）

## CIでチェックできなかった項目

- 親リポで `.env` を更新したあと、worktree で `pnpm worktree:copy-env` を叩くと最新の値が引き継がれること
- 親リポで実行するとエラー終了すること
- 既存ファイルとの差分判定（一致 → skip / 差分 → copy）が期待通りに動くこと

## 補足

- 関連: #678（Storybook / chrome-devtools MCP 衝突）/ #680（worktree-tips skill）
- worktree ごとに専用 group / db を切り出す運用も将来検討対象だが、コストとのトレードオフで現状は採用しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)