### PR TITLE
infra(ci): add Chromatic workflow for Storybook preview gated by with-storybook label

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,29 @@
+name: Chromatic
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: contains(github.event.pull_request.labels.*.name, 'with-storybook')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Run Chromatic
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: pnpm --filter @next-lift/react-components chromatic

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -33,6 +33,7 @@
 		"@types/react-dom": "19.2.3",
 		"@vitest/browser-playwright": "4.1.4",
 		"@vitest/coverage-v8": "4.1.4",
+		"chromatic": "16.6.3",
 		"playwright": "1.59.1",
 		"prop-types": "15.8.1",
 		"react": "19.2.5",
@@ -54,6 +55,7 @@
 		"type-check": "tsc --noEmit",
 		"storybook": "storybook dev --ci -p ${STORYBOOK_PORT:-6006} --exact-port",
 		"build-storybook": "storybook build",
+		"chromatic": "chromatic --exit-zero-on-changes --only-changed",
 		"ui:fetch": "pnpm dlx shadcn@latest add"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.4
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
+      chromatic:
+        specifier: 16.6.3
+        version: 16.6.3
       playwright:
         specifier: 1.59.1
         version: 1.59.1
@@ -4424,6 +4427,21 @@ packages:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+
+  chromatic@16.6.3:
+    resolution: {integrity: sha512-N9WCRuezqrxujRvgnAlE9XKxXcF6q2kowKH2Ba82FYkRc4xlY9g8r+ESEph9jLv500s43/9oDmB/kZ9r24BcgQ==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   chrome-launcher@0.15.2:
@@ -11818,6 +11836,10 @@ snapshots:
   chownr@3.0.0: {}
 
   chromatic@13.3.5: {}
+
+  chromatic@16.6.3:
+    dependencies:
+      semver: 7.7.3
 
   chrome-launcher@0.15.2:
     dependencies:


### PR DESCRIPTION
# 概要

UIライブラリ (`packages/react-components`) のPRレビューで、レビュアーがチェックアウト → install → 起動を行わないとStorybookのビジュアル確認ができず、レビューコストが高かった。Chromaticを導入してPRごとにStorybookをデプロイ + ビジュアルリグレッションテストを実行できるようにする。

ただし全PRで実行すると無料枠 5,000 snapshot/月 を超える可能性があるため、`with-preview` と同じく明示的にラベル (`with-storybook`) を付けたPRでのみ走らせる方式を採用した。

主な変更:

- `packages/react-components` に `chromatic` CLI (16.6.3) を追加し `pnpm chromatic` スクリプトを定義
- `.github/workflows/chromatic.yml` を追加し、`with-storybook` ラベル付きPRでのみChromaticを実行
- `with-storybook` ラベルをリポジトリに作成済み

設計詳細:

- `pnpm chromatic` 内で TurboSnap (`--only-changed`) を有効化し、変更影響分のみsnapshot取得
- `--exit-zero-on-changes` でビジュアル差分検出時もCIを落とさない（Chromatic UIで承認する運用）
- TurboSnap のgit履歴参照のため `fetch-depth: 0`
- PRコメント・コミットステータスはChromatic公式GitHub Appに任せる（独自コメントは追加しない）

Closes #690

## この変更による影響

- 開発者: `with-storybook` ラベル付きPRでChromaticビルドが走り、Storybookのビジュアル確認・差分レビューがブラウザ上で可能になる
- ラベル無しPRでは起動しないため既存のCI時間に影響なし
- 利用側 (`apps/web` など) には影響なし。`@next-lift/react-components` のpublic APIに変更はない

## CIでチェックできなかった項目

このPRのワークフロー自体は `CHROMATIC_PROJECT_TOKEN` Secret登録後でないと動作確認できないため、マージ前は手動でyaml構文チェックのみ実施済み。

マージ後、以下の手動セットアップが必要:

1. [Chromatic](https://www.chromatic.com/) でプロジェクトを作成し `CHROMATIC_PROJECT_TOKEN` を取得
2. `gh secret set CHROMATIC_PROJECT_TOKEN` でリポジトリSecretsに登録
3. Chromatic GitHub Appをリポジトリにインストール（PRコメント・ステータス連携用）

セットアップ後の動作確認:

- [ ] テストPRに `with-storybook` ラベルを付与し、Chromaticワークフローが起動することを確認
- [ ] ラベル無しPRでは起動しないことを確認
- [ ] ストーリーを変更した別PRで TurboSnap が効いて snapshot 数が抑えられることを確認
- [ ] Chromaticダッシュボードでsnapshot消費量が想定内であることを確認

## 補足

issue #690 では当初Claude (GitHub Action)が対応を試みたが、`.github/workflows/` 配下への書き込み権限がないため `chromatic.yml` を作成できず途中で失敗していた。今回はworktreeで残作業を引き継いで完了させた。

Claudeが先に作成したブランチ `infra/claude/issue-690-20260430-0146` は本PR完了後に不要なので削除可。