### PR TITLE
chore: typescriptの6系をpeer dependencyとして許容する

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,7 @@ packages:
   - packages/*
 
 nodeLinker: hoisted
+
+peerDependencyRules:
+  allowedVersions:
+    typescript: "6"


### PR DESCRIPTION
# 概要

`pnpm-workspace.yaml`に`peerDependencyRules.allowedVersions.typescript: "6"`を追加して、Renovateが新しい依存バージョンへ更新する際の`renovate/artifacts`失敗を解消する。

リポジトリはTypeScript 6.0.3を使用しているが、依存パッケージの一部（`@vercel/backends`、`@vercel/cervel`など）のpeerDependenciesが`^4.0.0 || ^5.0.0`のままでTS6を認識していない。`.npmrc`で`strict-peer-dependencies=true`が有効なため、Renovateが新しい依存バージョンへ更新するとlockfile生成時に`ERR_PNPM_PEER_DEP_ISSUES`で失敗していた：

```
.
└─┬ vercel 50.44.0
  ├─┬ @vercel/backends 0.0.59
  │ └── ✕ unmet peer typescript@"^4.0.0 || ^5.0.0": found 6.0.3
  └─┬ @vercel/express 0.1.72
    └─┬ @vercel/cervel 0.0.46
      └── ✕ unmet peer typescript@"^4.0.0 || ^5.0.0": found 6.0.3
```

結果、PR #694〜#697 の `renovate/artifacts` ステータスがFAILUREになり、CIが通らずマージできない状態になっていた。

## この変更による影響

- **Renovateの依存更新PR**: lockfile生成時にtypescriptのpeer dep違反で落ちていた問題が解消する。停滞していた #694〜#697 がmergeable状態に進む見込み。
- **開発者**: ローカルで`pnpm install`時に同種のpeer warningが出なくなる。lockfileには差分が出ないため既存の依存解決には影響なし。
- **ユーザー**: アプリ実行時の挙動には影響なし（pnpmの依存解決時のチェック設定のみ変更）。

## CIでチェックできなかった項目

- このPRマージ後、停滞している #694〜#697 のRenovate PRで `renovate/artifacts` が成功するかは、Renovateの再実行を待って確認する必要がある。

## 補足

- mainではすでにTS6でビルド・テスト・型チェックが通っており、ライブラリ側のpeer宣言が古いまま残っているだけ。ランタイム・型レベルの実害は確認できていない。
- `peerDependencyRules.allowedVersions`はtypescript peer depの6系のみ追加で許容する設定で、`strict-peer-dependencies=false`のような全体緩和ではない。
- ローカルで`pnpm install`を実行してlockfileに差分が出ないことを確認済み。
- マージ後、Renovate Dependency Dashboard (#1) からrebaseチェックボックスで個別に再実行をトリガーする可能性がある。