### PR TITLE
docs(react-components): WithAddAction の wrapper 構造に制約コメントを追加

### DIFF
--- a/packages/react-components/src/primitives/tabs/tabs.stories.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.stories.tsx
@@ -132,6 +132,7 @@ const WithAddActionDemo: FC = () => {
 	};
 	return (
 		<Tabs>
+			{/* react-aria の TabList は Collection ベースで Tab 以外の子要素は描画されないため、+ ボタンは TabList の兄弟として配置する */}
 			<div className="flex items-end gap-1 border-border border-b">
 				<TabList aria-label="Tabs" className="border-b-0">
 					{items.map((item) => (


### PR DESCRIPTION
# 概要

PR #701 マージ後に追加された迷子コミットを取り込むための PR。`tabs.stories.tsx` の `WithAddAction` の wrapper 構造に、`react-aria-components` の `TabList` Collection 制約に関するコメント (1 行) を追加する。

PR #701 マージ後に同じ feature/tabs-primitive ブランチへコメント追加コミットを push してしまい、main に入らない状態になっていたため、main 起点で新ブランチを切って cherry-pick した。

## この変更による影響

- コードの動作・型に影響なし (コメント追加のみ)
- views 実装で同じパターン (V2 の「+ Day 追加」等) を組むときに、なぜ Button を TabList の外に出しているのかがコードを読むだけで分かるようになる

## CIでチェックできなかった項目

- なし (コメント追加のみ)

## 補足

- 元の commit は feature/tabs-primitive ブランチに残っているが、PR #701 が merged 状態なので新ブランチで取り込む

🤖 Generated with [Claude Code](https://claude.com/claude-code)