### PR TITLE
refactor(react-components): スタイル定義パターン統一とルール明文化

### DIFF
--- a/packages/react-components/CLAUDE.md
+++ b/packages/react-components/CLAUDE.md
@@ -134,22 +134,79 @@ src/
 
 ### クラス名ユーティリティの使い分け
 
-#### `cn` - 通常のHTML要素用
+#### ルール 1: consumer の `className` 上書きには `cn` / `cx` が必須
+
+consumer が渡す `className` で tailwind-merge を効かせて安全な上書きを保証するために、`cn` / `cx` を必ず経由する。静的 class が 1 つだけでも必要。
+
+```tsx
+// ❌ 単純連結: p-2 と p-4 が両方 class に入り、CSS 適用順が build 順依存になる
+<Label className={`block p-2 ${className}`} />
+
+// ✅ cn 経由: tailwind-merge が p-4 を p-2 より優先させる
+<Label className={cn("block p-2", className)} />
+```
+
+#### ルール 2: `className` の型で `cn` と `cx` を使い分ける
+
+| 種別 | `className` の型 | 使うヘルパー |
+| --- | --- | --- |
+| 通常の HTML 要素（`div`, `span` 等） | `string \| undefined` | `cn` |
+| React Aria の string-only className（`Label`, `Text`, `Separator` 等） | `string \| undefined` | `cn` |
+| React Aria の render-prop className（`Button`, `Input`, `Group`, `ListBoxItem`, `MenuItem`, `Popover`, `ListBox`, `ComboBox`, `NumberField`, `TextField`, `FieldError`, `Tab`, `TabList`, `TabPanel`, `Tabs` 等） | `string \| ((v: RenderProps) => string) \| undefined` | `cx` |
+
+`cx`（`libs/primitive.ts`）は `composeRenderProps` を内部で使い、render-prop を関数のまま受けて最終的に `twMerge` する。`cn` を render-prop 対応の `className` に渡すと型エラーになる。逆に string-only の `className` に `cx` の戻り値（関数型）を渡してもエラーになる。
 
 ```typescript
 import { cn } from "@next-lift/react-components/libs";
 
-// 通常のHTML要素（div, pre, span等）に使用
+// HTML 要素 / React Aria の string-only className に使用
 <div className={cn("bg-primary", "text-white", className)} />
+<Label className={cn("block font-medium", className)} />
 ```
-
-#### `cx` - React Aria Components用
 
 ```typescript
 import { cx } from "@next-lift/react-components/libs";
 
-// React Aria Componentsに使用。classNameが関数（レンダープロップ）の場合もマージ可能
+// React Aria の render-prop 対応 className に使用
 <Button className={cx("bg-primary", className)} />
+<Tab className={cx("rounded-md font-medium", className)} />
+```
+
+#### ルール 3: static class は inline（`cn` / `cx` 可変引数）を default にする
+
+| 書き方 | 評価 |
+| --- | --- |
+| `cn("block p-2 text-fg", className)` | ✅ 推奨。一度しか参照しない static class は最も素直 |
+| `const labelClass = "block p-2 text-fg"; cn(labelClass, className)` | △ 同じ static class が **2 箇所以上** から参照される時のみ |
+| `tv({ base: ["block", "p-2"] })` — variants なし | ❌ 禁止。`tv` の利点（variant 拡張・twMerge）を使わない文字列定数と等価 |
+| `["block", "p-2"].join(" ")` | ❌ 禁止。可変引数で `cn` / `cx` に直接渡せばよい |
+| `tv({ base, variants: { ... } })` | ✅ variants / slots を使う場合のみ `tv` を使う |
+
+```tsx
+// ✅ 推奨: inline 可変引数
+<Label className={cn("block font-medium text-base/6 text-fg sm:text-sm/6", className)} />
+
+// ❌ 禁止: variants なしの tv
+const labelStyles = tv({ base: ["block", "font-medium"] });
+<Label className={cn(labelStyles(), className)} />
+
+// ❌ 禁止: .join(" ")
+const labelClass = ["block", "font-medium"].join(" ");
+```
+
+#### ルール 4: 配列 + `.join(" ")` は使わない
+
+`cn` / `cx` の可変引数（内部で `clsx` を使用）に直接渡す。
+
+```tsx
+// ❌
+const classes = ["flex", "flex-col", "gap-4"].join(" ");
+<div className={cn(classes, className)} />
+
+// ✅
+<div className={cn("flex", "flex-col", "gap-4", className)} />
+// または長い場合は一文字列で
+<div className={cn("flex flex-col gap-4", className)} />
 ```
 
 ### コンポーネントの利用

--- a/packages/react-components/src/primitives/tabs/tabs.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.tsx
@@ -11,13 +11,16 @@ import {
 	Tabs as TabsPrimitive,
 	type TabsProps as TabsPrimitiveProps,
 } from "react-aria-components";
-import { tv } from "tailwind-variants";
 import { cx } from "../../libs/primitive";
 
 export const Tabs: FC<TabsPrimitiveProps> = ({ className, ...props }) => (
 	<TabsPrimitive
 		data-slot="tabs"
-		className={cx(tabsStyles(), className)}
+		className={cx(
+			"flex flex-col gap-4",
+			"orientation-vertical:flex-row orientation-vertical:gap-6",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -28,7 +31,12 @@ export const TabList: FC<TabListPrimitiveProps<object>> = ({
 }) => (
 	<TabListPrimitive
 		data-slot="tab-list"
-		className={cx(tabListStyles(), className)}
+		className={cx(
+			"relative flex forced-color-adjust-none",
+			"orientation-horizontal:flex-row orientation-horizontal:gap-x-1 orientation-horizontal:border-border orientation-horizontal:border-b",
+			"orientation-vertical:min-w-48 orientation-vertical:shrink-0 orientation-vertical:flex-col orientation-vertical:gap-y-1 orientation-vertical:border-border orientation-vertical:border-l",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -36,7 +44,18 @@ export const TabList: FC<TabListPrimitiveProps<object>> = ({
 export const Tab: FC<TabPrimitiveProps> = ({ className, ...props }) => (
 	<TabPrimitive
 		data-slot="tab"
-		className={cx(tabStyles(), className)}
+		className={cx(
+			"relative inline-flex cursor-default items-center whitespace-nowrap rounded-md font-medium text-base/6 text-muted-fg outline-hidden transition-colors sm:text-sm/6",
+			"px-3 py-1.5",
+			"hover:bg-secondary hover:text-fg",
+			"selected:text-primary-subtle-fg selected:hover:bg-primary-subtle selected:hover:text-primary-subtle-fg",
+			"focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+			"disabled:opacity-50",
+			"after:pointer-events-none after:absolute after:bg-transparent",
+			"orientation-horizontal:after:inset-x-0 orientation-horizontal:after:-bottom-px orientation-horizontal:after:h-0.5 orientation-horizontal:selected:after:bg-primary-subtle-fg",
+			"orientation-vertical:w-full orientation-vertical:justify-start orientation-vertical:after:inset-y-1.5 orientation-vertical:after:-left-px orientation-vertical:after:w-0.5 orientation-vertical:selected:after:bg-primary-subtle-fg",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -47,7 +66,7 @@ export const TabPanel: FC<TabPanelPrimitiveProps> = ({
 }) => (
 	<TabPanelPrimitive
 		data-slot="tab-panel"
-		className={cx(tabPanelStyles(), className)}
+		className={cx("flex-1 text-fg outline-hidden", className)}
 		{...props}
 	/>
 );
@@ -60,36 +79,3 @@ export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => (
 		{children}
 	</div>
 );
-
-const tabsStyles = tv({
-	base: [
-		"flex flex-col gap-4",
-		"orientation-vertical:flex-row orientation-vertical:gap-6",
-	],
-});
-
-const tabListStyles = tv({
-	base: [
-		"relative flex forced-color-adjust-none",
-		"orientation-horizontal:flex-row orientation-horizontal:gap-x-1 orientation-horizontal:border-border orientation-horizontal:border-b",
-		"orientation-vertical:min-w-48 orientation-vertical:shrink-0 orientation-vertical:flex-col orientation-vertical:gap-y-1 orientation-vertical:border-border orientation-vertical:border-l",
-	],
-});
-
-const tabStyles = tv({
-	base: [
-		"relative inline-flex cursor-default items-center whitespace-nowrap rounded-md font-medium text-base/6 text-muted-fg outline-hidden transition-colors sm:text-sm/6",
-		"px-3 py-1.5",
-		"hover:bg-secondary hover:text-fg",
-		"selected:text-primary-subtle-fg selected:hover:bg-primary-subtle selected:hover:text-primary-subtle-fg",
-		"focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-		"disabled:opacity-50",
-		"after:pointer-events-none after:absolute after:bg-transparent",
-		"orientation-horizontal:after:inset-x-0 orientation-horizontal:after:-bottom-px orientation-horizontal:after:h-0.5 orientation-horizontal:selected:after:bg-primary-subtle-fg",
-		"orientation-vertical:w-full orientation-vertical:justify-start orientation-vertical:after:inset-y-1.5 orientation-vertical:after:-left-px orientation-vertical:after:w-0.5 orientation-vertical:selected:after:bg-primary-subtle-fg",
-	],
-});
-
-const tabPanelStyles = tv({
-	base: "flex-1 text-fg outline-hidden",
-});

--- a/packages/react-components/src/primitives/text-field/text-field.tsx
+++ b/packages/react-components/src/primitives/text-field/text-field.tsx
@@ -13,7 +13,6 @@ import {
 	type TextFieldProps as TextFieldPrimitiveProps,
 	type TextProps,
 } from "react-aria-components";
-import { tv } from "tailwind-variants";
 import { cx } from "../../libs/primitive";
 import { cn } from "../../libs/utils";
 
@@ -23,7 +22,16 @@ export const TextField: FC<TextFieldPrimitiveProps> = ({
 }) => (
 	<TextFieldPrimitive
 		data-slot="control"
-		className={cx(fieldStyles(), className)}
+		className={cx(
+			"w-full",
+			"[&>[data-slot=label]+[data-slot=control]]:mt-2",
+			"[&>[data-slot=label]+[slot='description']]:mt-1",
+			"[&>[slot=description]+[data-slot=control]]:mt-2",
+			"[&>[data-slot=control]+[slot=description]]:mt-2",
+			"[&>[data-slot=control]+[role=alert]]:mt-2",
+			"in-disabled:opacity-50",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -31,7 +39,12 @@ export const TextField: FC<TextFieldPrimitiveProps> = ({
 export const TextFieldLabel: FC<LabelProps> = ({ className, ...props }) => (
 	<LabelPrimitive
 		data-slot="label"
-		className={cn(labelStyles(), className)}
+		className={cn(
+			"block select-none font-medium text-base/6 text-fg sm:text-sm/6",
+			"in-data-[required=true]:after:ml-1.5 in-data-[required=true]:after:text-danger-subtle-fg in-data-[required=true]:after:content-['*']",
+			"in-disabled:opacity-50",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -39,7 +52,15 @@ export const TextFieldLabel: FC<LabelProps> = ({ className, ...props }) => (
 export const TextFieldInput: FC<InputProps> = ({ className, ...props }) => (
 	<InputPrimitive
 		data-slot="control"
-		className={cx(inputStyles(), className)}
+		className={cx(
+			"block min-h-10 w-full rounded-lg border border-border bg-overlay px-3 py-2 text-base/6 text-fg outline-none",
+			"placeholder:text-muted-fg",
+			"focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+			"invalid:border-danger",
+			"disabled:opacity-50",
+			"sm:min-h-9 sm:text-sm/6",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -50,7 +71,10 @@ export const TextFieldDescription: FC<TextProps> = ({
 }) => (
 	<Text
 		slot="description"
-		className={cn(descriptionStyles(), className)}
+		className={cn(
+			"block text-base/6 text-muted-fg in-disabled:opacity-50 sm:text-sm/6",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -60,46 +84,10 @@ export const TextFieldError: FC<FieldErrorProps> = ({
 	...props
 }) => (
 	<FieldErrorPrimitive
-		className={cx(fieldErrorStyles(), className)}
+		className={cx(
+			"block text-base/6 text-danger-subtle-fg in-disabled:opacity-50 sm:text-sm/6 forced-colors:text-[Mark]",
+			className,
+		)}
 		{...props}
 	/>
 );
-
-const fieldStyles = tv({
-	base: [
-		"w-full",
-		"[&>[data-slot=label]+[data-slot=control]]:mt-2",
-		"[&>[data-slot=label]+[slot='description']]:mt-1",
-		"[&>[slot=description]+[data-slot=control]]:mt-2",
-		"[&>[data-slot=control]+[slot=description]]:mt-2",
-		"[&>[data-slot=control]+[role=alert]]:mt-2",
-		"in-disabled:opacity-50",
-	],
-});
-
-const labelStyles = tv({
-	base: [
-		"block select-none font-medium text-base/6 text-fg sm:text-sm/6",
-		"in-data-[required=true]:after:ml-1.5 in-data-[required=true]:after:text-danger-subtle-fg in-data-[required=true]:after:content-['*']",
-		"in-disabled:opacity-50",
-	],
-});
-
-const inputStyles = tv({
-	base: [
-		"block min-h-10 w-full rounded-lg border border-border bg-overlay px-3 py-2 text-base/6 text-fg outline-none",
-		"placeholder:text-muted-fg",
-		"focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-		"invalid:border-danger",
-		"disabled:opacity-50",
-		"sm:min-h-9 sm:text-sm/6",
-	],
-});
-
-const descriptionStyles = tv({
-	base: "block text-base/6 text-muted-fg in-disabled:opacity-50 sm:text-sm/6",
-});
-
-const fieldErrorStyles = tv({
-	base: "block text-base/6 text-danger-subtle-fg in-disabled:opacity-50 sm:text-sm/6 forced-colors:text-[Mark]",
-});


### PR DESCRIPTION
Closes #722

## 変更内容

- `CLAUDE.md` にスタイル定義 4 ルールを明記
- `text-field.tsx`: `tv({base})` を inline `cn`/`cx` に変換
- `tabs.tsx`: `tv({base})` を inline `cx` に変換

Generated with [Claude Code](https://claude.ai/code)