### PR TITLE
feat: TabScrollArea にスクロールフェードを追加

### DIFF
--- a/packages/react-components/src/primitives/tabs/tabs.stories.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.stories.tsx
@@ -276,3 +276,40 @@ export const WithScrollableTabs: Story = {
 		</Tabs>
 	),
 };
+
+const mobileDays = Array.from({ length: 12 }, (_, i) => ({
+	id: `day-${i + 1}`,
+	label: `Day ${i + 1}`,
+}));
+
+export const MobileScrollable: Story = {
+	parameters: {
+		layout: "fullscreen",
+		viewport: { defaultViewport: "mobile" },
+	},
+	decorators: [
+		(Story) => (
+			<div className="p-4">
+				<Story />
+			</div>
+		),
+	],
+	render: () => (
+		<Tabs>
+			<TabScrollArea>
+				<TabList aria-label="Day">
+					{mobileDays.map((day) => (
+						<Tab key={day.id} id={day.id}>
+							{day.label}
+						</Tab>
+					))}
+				</TabList>
+			</TabScrollArea>
+			{mobileDays.map((day) => (
+				<TabPanel key={day.id} id={day.id}>
+					<p>{day.label} の内容</p>
+				</TabPanel>
+			))}
+		</Tabs>
+	),
+};

--- a/packages/react-components/src/primitives/tabs/tabs.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-	type FC,
-	type PropsWithChildren,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
+import type { FC, PropsWithChildren } from "react";
 import {
 	TabList as TabListPrimitive,
 	type TabListProps as TabListPrimitiveProps,
@@ -77,40 +71,29 @@ export const TabPanel: FC<TabPanelPrimitiveProps> = ({
 	/>
 );
 
-export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => {
-	const scrollRef = useRef<HTMLDivElement>(null);
-	const [canScrollLeft, setCanScrollLeft] = useState(false);
-	const [canScrollRight, setCanScrollRight] = useState(false);
-
-	const updateScrollState = () => {
-		const el = scrollRef.current;
-		if (!el) return;
-		setCanScrollLeft(el.scrollLeft > 0);
-		setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-	};
-
-	useEffect(() => {
-		const el = scrollRef.current;
-		if (!el) return;
-		setCanScrollLeft(el.scrollLeft > 0);
-		setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-	}, []);
-
-	return (
-		<div data-slot="tab-scroll-area" className="relative">
-			<div
-				ref={scrollRef}
-				className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-				onScroll={updateScrollState}
-			>
-				{children}
-			</div>
-			{canScrollLeft && (
-				<div className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent" />
-			)}
-			{canScrollRight && (
-				<div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent" />
-			)}
+export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => (
+	<div
+		data-slot="tab-scroll-area"
+		className="relative [timeline-scope:--tab-scroll]"
+	>
+		<div className="overflow-x-auto [scroll-timeline-axis:inline] [scroll-timeline-name:--tab-scroll] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			{children}
 		</div>
-	);
-};
+		<TabScrollFadeStart />
+		<TabScrollFadeEnd />
+	</div>
+);
+
+const TabScrollFadeStart: FC = () => (
+	<div
+		aria-hidden="true"
+		className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-start] [animation-timeline:--tab-scroll]"
+	/>
+);
+
+const TabScrollFadeEnd: FC = () => (
+	<div
+		aria-hidden="true"
+		className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-end] [animation-timeline:--tab-scroll]"
+	/>
+);

--- a/packages/react-components/src/primitives/tabs/tabs.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type FC, type PropsWithChildren, useEffect, useRef, useState } from "react";
+import {
+	type FC,
+	type PropsWithChildren,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import {
 	TabList as TabListPrimitive,
 	type TabListProps as TabListPrimitiveProps,
@@ -84,7 +90,10 @@ export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => {
 	};
 
 	useEffect(() => {
-		updateScrollState();
+		const el = scrollRef.current;
+		if (!el) return;
+		setCanScrollLeft(el.scrollLeft > 0);
+		setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
 	}, []);
 
 	return (

--- a/packages/react-components/src/primitives/tabs/tabs.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { FC, PropsWithChildren } from "react";
+import { type FC, type PropsWithChildren, useEffect, useRef, useState } from "react";
 import {
 	TabList as TabListPrimitive,
 	type TabListProps as TabListPrimitiveProps,
@@ -71,11 +71,37 @@ export const TabPanel: FC<TabPanelPrimitiveProps> = ({
 	/>
 );
 
-export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => (
-	<div
-		data-slot="tab-scroll-area"
-		className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-	>
-		{children}
-	</div>
-);
+export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => {
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const [canScrollLeft, setCanScrollLeft] = useState(false);
+	const [canScrollRight, setCanScrollRight] = useState(false);
+
+	const updateScrollState = () => {
+		const el = scrollRef.current;
+		if (!el) return;
+		setCanScrollLeft(el.scrollLeft > 0);
+		setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+	};
+
+	useEffect(() => {
+		updateScrollState();
+	}, []);
+
+	return (
+		<div data-slot="tab-scroll-area" className="relative">
+			<div
+				ref={scrollRef}
+				className="overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+				onScroll={updateScrollState}
+			>
+				{children}
+			</div>
+			{canScrollLeft && (
+				<div className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent" />
+			)}
+			{canScrollRight && (
+				<div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent" />
+			)}
+		</div>
+	);
+};

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -284,3 +284,23 @@ body {
 		z-index: 9999;
 	}
 }
+
+@keyframes tab-scroll-fade-start {
+	0% {
+		opacity: 0;
+	}
+	1%,
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes tab-scroll-fade-end {
+	0%,
+	99% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}


### PR DESCRIPTION
# 概要

Close #739

TabScrollArea にスクロール可能性を示すフェードオーバーレイを追加。

CSS の scroll-driven animations（`scroll-timeline` / `animation-timeline`）でフェード可視性を宣言的に制御し、useState / useEffect / useRef を一切使わずに実装する。

- `scroll-timeline` を内側スクロール要素に定義、親に `timeline-scope` を付け、フェード兄弟要素から `animation-timeline` で参照
- @keyframes で「スクロール余地に応じた opacity」を定義（0%↔1% で start fade、99%↔100% で end fade を切替）
- 静的フォールバック opacity 0 にすることで、scroll-timeline が inactive（オーバーフロー無し）の場合はフェードが出ない
- フェード要素には `aria-hidden="true"` を付与して SR から隠蔽
- Storybook に MobileScrollable ストーリー追加（375px ビューポート + 12 タブ）

## この変更による影響

- アプリ利用者: タブが横スクロール可能であることを視覚的に示すフェードが追加される
- パッケージ利用側: `TabScrollArea` の API は変わらず、内部実装のみ変更
- ブラウザサポート:
  - Chrome / Edge 115+, Safari 26+: フェードが表示される
  - Firefox: scroll-driven animations 未対応のためフェードは出ないが、スクロール挙動は機能する（progressive enhancement）

## CIでチェックできなかった項目

- 実機タッチデバイスでの慣性スクロール挙動の自然さ
- フェード色（`--overlay`）が consumer 側の背景色と一致しない場面でのフェードの見え方

## 補足

- Firefox は CSS scroll-driven animations の未対応（baseline: limited availability）。この機能は装飾扱いとし、フォールバックは「フェードなし」で許容
- React.md の「派生値はEffectで同期するな」原則に従い、DOMスクロール状態をstateにコピーする実装を撤廃
- @keyframes は `packages/tailwind-config/tailwind.css` に追加（apps/web と Storybook 双方が参照する共有シート）