### PR TITLE
refactor(react-components): Tailwind canonical class と react-aria deprecated API を一括修正

### DIFF
--- a/packages/react-components/src/primitives/combo-box/combo-box.stories.tsx
+++ b/packages/react-components/src/primitives/combo-box/combo-box.stories.tsx
@@ -74,7 +74,7 @@ export const WithDescription: Story = {
 export const WithDefaultSelection: Story = {
 	name: "選択済み",
 	render: () => (
-		<ComboBox defaultSelectedKey="squat">
+		<ComboBox defaultValue="squat">
 			<ComboBoxLabel>種目</ComboBoxLabel>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxList items={exercises}>
@@ -166,7 +166,7 @@ const CREATE_OPTION_ID = "__create__";
 const CreateNewOptionDemo = () => {
 	const [registered, setRegistered] = useState(exercises);
 	const [inputValue, setInputValue] = useState("");
-	const [selectedKey, setSelectedKey] = useState<Key | null>(null);
+	const [value, setValue] = useState<Key | null>(null);
 
 	const items = useMemo(() => {
 		const trimmed = inputValue.trim();
@@ -183,16 +183,16 @@ const CreateNewOptionDemo = () => {
 		return filtered;
 	}, [inputValue, registered]);
 
-	const onSelectionChange = (key: Key | null) => {
+	const onChange = (key: Key | null) => {
 		if (key === CREATE_OPTION_ID) {
 			const trimmed = inputValue.trim();
 			const newId = `custom-${Date.now()}`;
 			setRegistered((prev) => [...prev, { id: newId, name: trimmed }]);
-			setSelectedKey(newId);
+			setValue(newId);
 			setInputValue(trimmed);
 			return;
 		}
-		setSelectedKey(key);
+		setValue(key);
 		const matched = registered.find((e) => e.id === key);
 		if (matched !== undefined) {
 			setInputValue(matched.name);
@@ -204,8 +204,8 @@ const CreateNewOptionDemo = () => {
 			items={items}
 			inputValue={inputValue}
 			onInputChange={setInputValue}
-			selectedKey={selectedKey}
-			onSelectionChange={onSelectionChange}
+			value={value}
+			onChange={onChange}
 			allowsCustomValue
 		>
 			<ComboBoxLabel>種目</ComboBoxLabel>
@@ -218,7 +218,7 @@ const CreateNewOptionDemo = () => {
 					item.id === CREATE_OPTION_ID ? (
 						<ComboBoxItem
 							id={item.id}
-							className="text-primary data-[focused]:bg-primary/10 data-[focused]:text-primary"
+							className="text-primary data-focused:bg-primary/10 data-focused:text-primary"
 						>
 							{item.name}
 						</ComboBoxItem>

--- a/packages/react-components/src/primitives/combo-box/combo-box.tsx
+++ b/packages/react-components/src/primitives/combo-box/combo-box.tsx
@@ -64,8 +64,8 @@ export const ComboBoxInput: FC<InputProps> = ({ className, ...props }) => (
 		className={cx(
 			"flex w-full overflow-hidden rounded-lg border border-border bg-overlay",
 			"focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-bg",
-			"data-[invalid]:border-danger",
-			"data-[disabled]:opacity-50",
+			"data-invalid:border-danger",
+			"data-disabled:opacity-50",
 		)}
 	>
 		<InputPrimitive
@@ -132,10 +132,10 @@ export const ComboBoxItem = <T extends object>({
 	<ListBoxItemPrimitive
 		className={cx(
 			"relative flex cursor-default select-none items-center gap-2 rounded-md px-3 py-2 text-base/6 text-fg outline-none",
-			"data-[hovered]:bg-accent data-[hovered]:text-accent-fg",
-			"data-[focused]:bg-accent data-[focused]:text-accent-fg",
-			"data-[selected]:bg-accent/60 data-[selected]:text-accent-fg",
-			"data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+			"data-hovered:bg-accent data-hovered:text-accent-fg",
+			"data-focused:bg-accent data-focused:text-accent-fg",
+			"data-selected:bg-accent/60 data-selected:text-accent-fg",
+			"data-disabled:pointer-events-none data-disabled:opacity-50",
 			"sm:px-2.5 sm:py-1.5 sm:text-sm/6",
 			className,
 		)}

--- a/packages/react-components/src/primitives/menu/menu.tsx
+++ b/packages/react-components/src/primitives/menu/menu.tsx
@@ -50,19 +50,19 @@ export const Menu = <T extends object>({
 const menuItemStyles = tv({
 	base: [
 		"relative flex cursor-default select-none items-center gap-2 rounded-md px-3 py-2 text-base/6 text-fg outline-none",
-		"data-[hovered]:bg-accent data-[hovered]:text-accent-fg",
-		"data-[focused]:bg-accent data-[focused]:text-accent-fg",
-		"data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+		"data-hovered:bg-accent data-hovered:text-accent-fg",
+		"data-focused:bg-accent data-focused:text-accent-fg",
+		"data-disabled:pointer-events-none data-disabled:opacity-50",
 		"sm:px-2.5 sm:py-1.5 sm:text-sm/6",
-		"forced-colors:data-[focused]:bg-[Highlight] forced-colors:data-[focused]:text-[HighlightText]",
+		"forced-colors:data-focused:bg-[Highlight] forced-colors:data-focused:text-[HighlightText]",
 	],
 	variants: {
 		intent: {
 			danger: [
 				"text-danger-subtle-fg",
-				"data-[hovered]:bg-danger-subtle data-[hovered]:text-danger-subtle-fg",
-				"data-[focused]:bg-danger-subtle data-[focused]:text-danger-subtle-fg",
-				"forced-colors:data-[focused]:text-[Mark]",
+				"data-hovered:bg-danger-subtle data-hovered:text-danger-subtle-fg",
+				"data-focused:bg-danger-subtle data-focused:text-danger-subtle-fg",
+				"forced-colors:data-focused:text-[Mark]",
 			],
 		},
 	},

--- a/packages/react-components/src/primitives/number-field/number-field.tsx
+++ b/packages/react-components/src/primitives/number-field/number-field.tsx
@@ -59,8 +59,8 @@ export const NumberFieldInput: FC<InputProps> = ({ className, ...props }) => (
 		className={cx(
 			"flex w-full overflow-hidden rounded-lg border border-border bg-overlay",
 			"focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-bg",
-			"data-[invalid]:border-danger",
-			"data-[disabled]:opacity-50",
+			"data-invalid:border-danger",
+			"data-disabled:opacity-50",
 		)}
 	>
 		<NumberFieldStepperButton slot="decrement" aria-label="減らす">

--- a/packages/react-components/src/views/program-detail/index.tsx
+++ b/packages/react-components/src/views/program-detail/index.tsx
@@ -42,7 +42,7 @@ export const ProgramDetail: FC<Props> = ({
 }) => {
 	const tabsProps =
 		defaultSelectedDayId !== undefined
-			? { defaultSelectedKey: defaultSelectedDayId }
+			? { defaultValue: defaultSelectedDayId }
 			: {};
 	return (
 		<div className="flex flex-col gap-6">


### PR DESCRIPTION
# 概要

Closes #740

`@next-lift/react-components` に残っていた IDE 警告 2 種を一括解消するリファクタリング。

- Tailwind canonical class への置換: bracket 形式 `data-[focused]:` などを `tailwindcss-react-aria-components` が登録する canonical variant `data-focused:` に統一
- react-aria-components の deprecated API（`selectedKey` / `defaultSelectedKey` / `onSelectionChange`）を新 API（`value` / `defaultValue` / `onChange`）へ置換

## この変更による影響

- パッケージ利用側: 公開コンポーネントの型は変わるが、本リポジトリ内で deprecated API を使っている箇所は同 PR 内で修正済み
- IDE 警告 16 件超が解消し、エディタ上のノイズが減る
- 次の `react-aria-components` メジャー更新で deprecated API がエラー化するリスクを先取りで除去

## CIでチェックできなかった項目

- 各プリミティブ（ComboBox / Menu / NumberField / Tabs）の見た目に視覚的な regression がないかの目視確認
- 実機・キーボード操作でのフォーカス/ホバー/選択状態の見た目

## 補足

修正対象は `combo-box`, `menu`, `number-field`, `program-detail` の 5 ファイル。Storybook で該当ストーリーを開いて挙動を確認できる。