### PR TITLE
feat: add Scrollable primitive (#759)

### DIFF
--- a/packages/react-components/src/primitives/index.ts
+++ b/packages/react-components/src/primitives/index.ts
@@ -9,5 +9,6 @@ export * from "./main";
 export * from "./menu";
 export * from "./modal";
 export * from "./number-field";
+export * from "./scrollable";
 export * from "./tabs";
 export * from "./text-field";

--- a/packages/react-components/src/primitives/scrollable/compute-scroll-left.test.ts
+++ b/packages/react-components/src/primitives/scrollable/compute-scroll-left.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import { computeScrollLeft } from "./compute-scroll-left";
+
+describe("computeScrollLeft", () => {
+	const baseGeometry = {
+		containerWidth: 200,
+		containerScrollLeft: 0,
+		targetLeft: 500,
+		targetWidth: 60,
+	};
+
+	describe("align: start", () => {
+		test("ターゲットの左端がコンテナの左端に揃う位置を返すこと", () => {
+			expect(computeScrollLeft(baseGeometry, "start")).toBe(500);
+		});
+
+		test("ターゲットが左端より前なら 0 にクランプされること", () => {
+			expect(
+				computeScrollLeft({ ...baseGeometry, targetLeft: -50 }, "start"),
+			).toBe(0);
+		});
+	});
+
+	describe("align: end", () => {
+		test("ターゲットの右端がコンテナの右端に揃う位置を返すこと", () => {
+			expect(computeScrollLeft(baseGeometry, "end")).toBe(360);
+		});
+
+		test("結果が負になるなら 0 にクランプされること", () => {
+			expect(
+				computeScrollLeft({ ...baseGeometry, targetLeft: 50 }, "end"),
+			).toBe(0);
+		});
+	});
+
+	describe("align: center", () => {
+		test("ターゲットの中央がコンテナの中央に揃う位置を返すこと", () => {
+			expect(computeScrollLeft(baseGeometry, "center")).toBe(430);
+		});
+
+		test("結果が負になるなら 0 にクランプされること", () => {
+			expect(
+				computeScrollLeft({ ...baseGeometry, targetLeft: 0 }, "center"),
+			).toBe(0);
+		});
+	});
+
+	describe("align: nearest", () => {
+		describe("ターゲットが既にビュー内にあるとき", () => {
+			test("現在の scrollLeft をそのまま返すこと", () => {
+				expect(
+					computeScrollLeft(
+						{
+							containerWidth: 200,
+							containerScrollLeft: 480,
+							targetLeft: 500,
+							targetWidth: 60,
+						},
+						"nearest",
+					),
+				).toBe(480);
+			});
+		});
+
+		describe("ターゲットがビューの左外にあるとき", () => {
+			test("ターゲットの左端を左端に合わせる位置を返すこと", () => {
+				expect(
+					computeScrollLeft(
+						{
+							containerWidth: 200,
+							containerScrollLeft: 600,
+							targetLeft: 500,
+							targetWidth: 60,
+						},
+						"nearest",
+					),
+				).toBe(500);
+			});
+		});
+
+		describe("ターゲットがビューの右外にあるとき", () => {
+			test("ターゲットの右端を右端に合わせる位置を返すこと", () => {
+				expect(
+					computeScrollLeft(
+						{
+							containerWidth: 200,
+							containerScrollLeft: 0,
+							targetLeft: 500,
+							targetWidth: 60,
+						},
+						"nearest",
+					),
+				).toBe(360);
+			});
+		});
+	});
+});

--- a/packages/react-components/src/primitives/scrollable/compute-scroll-left.ts
+++ b/packages/react-components/src/primitives/scrollable/compute-scroll-left.ts
@@ -1,0 +1,33 @@
+export type ScrollAlign = "start" | "center" | "end" | "nearest";
+
+type Geometry = {
+	containerWidth: number;
+	containerScrollLeft: number;
+	targetLeft: number;
+	targetWidth: number;
+};
+
+export const computeScrollLeft = (
+	{ containerWidth, containerScrollLeft, targetLeft, targetWidth }: Geometry,
+	align: ScrollAlign,
+): number => {
+	const targetRight = targetLeft + targetWidth;
+
+	if (align === "start") {
+		return Math.max(0, targetLeft);
+	}
+	if (align === "end") {
+		return Math.max(0, targetRight - containerWidth);
+	}
+	if (align === "center") {
+		return Math.max(0, targetLeft + targetWidth / 2 - containerWidth / 2);
+	}
+
+	if (targetLeft < containerScrollLeft) {
+		return Math.max(0, targetLeft);
+	}
+	if (targetRight > containerScrollLeft + containerWidth) {
+		return Math.max(0, targetRight - containerWidth);
+	}
+	return containerScrollLeft;
+};

--- a/packages/react-components/src/primitives/scrollable/index.ts
+++ b/packages/react-components/src/primitives/scrollable/index.ts
@@ -1,0 +1,1 @@
+export * from "./scrollable";

--- a/packages/react-components/src/primitives/scrollable/scrollable.stories.tsx
+++ b/packages/react-components/src/primitives/scrollable/scrollable.stories.tsx
@@ -91,3 +91,27 @@ export const ManyItems: Story = {
 		</ScrollArea>
 	),
 };
+
+export const InitialScrollPosition: Story = {
+	render: () => {
+		const initiallySelectedId = "rpe-8";
+		return (
+			<ScrollArea scrollAlign="center">
+				<div className="flex gap-1">
+					{rpeValues.map((rpe) => (
+						<Button
+							key={rpe.id}
+							intent={rpe.id === initiallySelectedId ? "primary" : "outline"}
+							size="sm"
+							data-initial-scroll={
+								rpe.id === initiallySelectedId ? "" : undefined
+							}
+						>
+							{rpe.label}
+						</Button>
+					))}
+				</div>
+			</ScrollArea>
+		);
+	},
+};

--- a/packages/react-components/src/primitives/scrollable/scrollable.stories.tsx
+++ b/packages/react-components/src/primitives/scrollable/scrollable.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import type { ComponentProps } from "react";
+import { cn } from "../../libs/utils";
 import { Button } from "../button/button";
 import { ScrollArea } from "./scrollable";
 
@@ -115,3 +117,54 @@ export const InitialScrollPosition: Story = {
 		);
 	},
 };
+
+export const FadeFromPatterns: Story = {
+	parameters: {
+		layout: "fullscreen",
+	},
+	decorators: [
+		(Story) => (
+			<div className="bg-bg p-4">
+				<Story />
+			</div>
+		),
+	],
+	render: () => (
+		<div className="flex flex-col gap-6">
+			{fadePatterns.map(({ fadeFrom, containerClassName }) => (
+				<section key={fadeFrom} className="flex flex-col gap-1">
+					<span className="font-mono text-muted-fg text-xs">
+						fadeFrom=&quot;{fadeFrom}&quot;
+					</span>
+					<div
+						className={cn(
+							"w-64 rounded-md border border-border p-2",
+							containerClassName,
+						)}
+					>
+						<ScrollArea fadeFrom={fadeFrom}>
+							<div className="flex gap-1">
+								{rpeValues.map((rpe) => (
+									<Button key={rpe.id} intent="outline" size="sm">
+										{rpe.label}
+									</Button>
+								))}
+							</div>
+						</ScrollArea>
+					</div>
+				</section>
+			))}
+		</div>
+	),
+};
+
+type FadeFromValue = NonNullable<ComponentProps<typeof ScrollArea>["fadeFrom"]>;
+
+const fadePatterns: { fadeFrom: FadeFromValue; containerClassName: string }[] =
+	[
+		{ fadeFrom: "bg", containerClassName: "bg-bg" },
+		{ fadeFrom: "overlay", containerClassName: "bg-overlay" },
+		{ fadeFrom: "navbar", containerClassName: "bg-navbar" },
+		{ fadeFrom: "sidebar", containerClassName: "bg-sidebar" },
+		{ fadeFrom: "secondary", containerClassName: "bg-secondary" },
+	];

--- a/packages/react-components/src/primitives/scrollable/scrollable.stories.tsx
+++ b/packages/react-components/src/primitives/scrollable/scrollable.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../button/button";
+import { ScrollArea } from "./scrollable";
+
+const meta = {
+	title: "UI/ScrollArea",
+	component: ScrollArea,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+	decorators: [
+		(Story) => (
+			<div className="w-64 rounded-md border border-border bg-overlay p-2">
+				<Story />
+			</div>
+		),
+	],
+} satisfies Meta<typeof ScrollArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const rpeValues = [
+	{ id: "none", label: "なし" },
+	{ id: "rpe-6", label: "6" },
+	{ id: "rpe-6-5", label: "6.5" },
+	{ id: "rpe-7", label: "7" },
+	{ id: "rpe-7-5", label: "7.5" },
+	{ id: "rpe-8", label: "8" },
+	{ id: "rpe-8-5", label: "8.5" },
+	{ id: "rpe-9", label: "9" },
+	{ id: "rpe-9-5", label: "9.5" },
+	{ id: "rpe-10", label: "10" },
+	{ id: "rpe-10-5", label: "10.5" },
+];
+
+export const Default: Story = {
+	render: () => (
+		<ScrollArea>
+			<div className="flex gap-1">
+				{rpeValues.map((rpe) => (
+					<Button key={rpe.id} intent="outline" size="sm">
+						{rpe.label}
+					</Button>
+				))}
+			</div>
+		</ScrollArea>
+	),
+};
+
+export const Narrow: Story = {
+	parameters: {
+		layout: "fullscreen",
+	},
+	decorators: [
+		(Story) => (
+			<div className="w-48 rounded-md border border-border bg-overlay p-2">
+				<Story />
+			</div>
+		),
+	],
+	render: () => (
+		<ScrollArea>
+			<div className="flex gap-1">
+				{rpeValues.map((rpe) => (
+					<Button key={rpe.id} intent="outline" size="sm">
+						{rpe.label}
+					</Button>
+				))}
+			</div>
+		</ScrollArea>
+	),
+};
+
+const manyItems = Array.from({ length: 20 }, (_, i) => ({
+	id: `item-${i + 1}`,
+	label: `項目 ${i + 1}`,
+}));
+
+export const ManyItems: Story = {
+	render: () => (
+		<ScrollArea>
+			<div className="flex gap-1">
+				{manyItems.map((item) => (
+					<Button key={item.id} intent="secondary" size="sm">
+						{item.label}
+					</Button>
+				))}
+			</div>
+		</ScrollArea>
+	),
+};

--- a/packages/react-components/src/primitives/scrollable/scrollable.tsx
+++ b/packages/react-components/src/primitives/scrollable/scrollable.tsx
@@ -1,27 +1,28 @@
 "use client";
 
-import { type FC, type PropsWithChildren, useEffect, useRef } from "react";
+import { type FC, type PropsWithChildren, useRef } from "react";
+import { tv, type VariantProps } from "tailwind-variants";
 import { cn } from "../../libs/utils";
 import { computeScrollLeft, type ScrollAlign } from "./compute-scroll-left";
 
-type Props = PropsWithChildren<{
-	className?: string;
-	fadeFrom?: string;
-	scrollAlign?: ScrollAlign;
-}>;
+type Props = PropsWithChildren<
+	VariantProps<typeof fadeStyles> & {
+		className?: string;
+		scrollAlign?: ScrollAlign;
+	}
+>;
 
 export const ScrollArea: FC<Props> = ({
 	children,
 	className,
-	fadeFrom = "from-overlay",
+	fadeFrom,
 	scrollAlign = "nearest",
 }) => {
-	const scrollRef = useRef<HTMLDivElement>(null);
+	const initializedRef = useRef(false);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: 初期表示時のみ scrollLeft を設定する。マウント後の prop 変化には反応しない（uncontrolled の慣習）
-	useEffect(() => {
-		const container = scrollRef.current;
-		if (!container) return;
+	const setContainer = (container: HTMLDivElement | null) => {
+		if (!container || initializedRef.current) return;
+		initializedRef.current = true;
 		const target = container.querySelector<HTMLElement>(
 			"[data-initial-scroll]",
 		);
@@ -37,7 +38,7 @@ export const ScrollArea: FC<Props> = ({
 			},
 			scrollAlign,
 		);
-	}, []);
+	};
 
 	return (
 		<div
@@ -45,7 +46,7 @@ export const ScrollArea: FC<Props> = ({
 			className={cn("relative [timeline-scope:--scrollable]", className)}
 		>
 			<div
-				ref={scrollRef}
+				ref={setContainer}
 				className="overflow-x-auto [scroll-timeline-axis:inline] [scroll-timeline-name:--scrollable] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 			>
 				{children}
@@ -53,17 +54,32 @@ export const ScrollArea: FC<Props> = ({
 			<div
 				aria-hidden="true"
 				className={cn(
-					"pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--scrollable]",
-					fadeFrom,
+					"pointer-events-none absolute inset-y-0 left-0 w-8 bg-linear-to-r to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--scrollable]",
+					fadeStyles({ fadeFrom }),
 				)}
 			/>
 			<div
 				aria-hidden="true"
 				className={cn(
-					"pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--scrollable]",
-					fadeFrom,
+					"pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--scrollable]",
+					fadeStyles({ fadeFrom }),
 				)}
 			/>
 		</div>
 	);
 };
+
+const fadeStyles = tv({
+	variants: {
+		fadeFrom: {
+			bg: "from-bg",
+			overlay: "from-overlay",
+			navbar: "from-navbar",
+			sidebar: "from-sidebar",
+			secondary: "from-secondary",
+		},
+	},
+	defaultVariants: {
+		fadeFrom: "overlay",
+	},
+});

--- a/packages/react-components/src/primitives/scrollable/scrollable.tsx
+++ b/packages/react-components/src/primitives/scrollable/scrollable.tsx
@@ -54,14 +54,14 @@ export const ScrollArea: FC<Props> = ({
 			<div
 				aria-hidden="true"
 				className={cn(
-					"pointer-events-none absolute inset-y-0 left-0 w-8 bg-linear-to-r to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--scrollable]",
+					"pointer-events-none absolute inset-y-0 left-0 w-8 bg-linear-to-r to-transparent fill-mode-[both] opacity-0 [animation-name:scroll-fade-start] [animation-timeline:--scrollable]",
 					fadeStyles({ fadeFrom }),
 				)}
 			/>
 			<div
 				aria-hidden="true"
 				className={cn(
-					"pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--scrollable]",
+					"pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l to-transparent fill-mode-[both] opacity-0 [animation-name:scroll-fade-end] [animation-timeline:--scrollable]",
 					fadeStyles({ fadeFrom }),
 				)}
 			/>
@@ -69,6 +69,7 @@ export const ScrollArea: FC<Props> = ({
 	);
 };
 
+// 親コンテナの背景色トークンに合わせる（フェードを背景に溶け込ませるため）
 const fadeStyles = tv({
 	variants: {
 		fadeFrom: {

--- a/packages/react-components/src/primitives/scrollable/scrollable.tsx
+++ b/packages/react-components/src/primitives/scrollable/scrollable.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { FC, PropsWithChildren } from "react";
+import { cn } from "../../libs/utils";
+
+type Props = PropsWithChildren<{
+	className?: string;
+	fadeFrom?: string;
+}>;
+
+export const ScrollArea: FC<Props> = ({
+	children,
+	className,
+	fadeFrom = "from-overlay",
+}) => (
+	<div
+		data-slot="scroll-area"
+		className={cn("relative [timeline-scope:--scrollable]", className)}
+	>
+		<div className="overflow-x-auto [scroll-timeline-axis:inline] [scroll-timeline-name:--scrollable] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			{children}
+		</div>
+		<div
+			aria-hidden="true"
+			className={cn(
+				"pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--scrollable]",
+				fadeFrom,
+			)}
+		/>
+		<div
+			aria-hidden="true"
+			className={cn(
+				"pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--scrollable]",
+				fadeFrom,
+			)}
+		/>
+	</div>
+);

--- a/packages/react-components/src/primitives/scrollable/scrollable.tsx
+++ b/packages/react-components/src/primitives/scrollable/scrollable.tsx
@@ -1,38 +1,69 @@
 "use client";
 
-import type { FC, PropsWithChildren } from "react";
+import { type FC, type PropsWithChildren, useEffect, useRef } from "react";
 import { cn } from "../../libs/utils";
+import { computeScrollLeft, type ScrollAlign } from "./compute-scroll-left";
 
 type Props = PropsWithChildren<{
 	className?: string;
 	fadeFrom?: string;
+	scrollAlign?: ScrollAlign;
 }>;
 
 export const ScrollArea: FC<Props> = ({
 	children,
 	className,
 	fadeFrom = "from-overlay",
-}) => (
-	<div
-		data-slot="scroll-area"
-		className={cn("relative [timeline-scope:--scrollable]", className)}
-	>
-		<div className="overflow-x-auto [scroll-timeline-axis:inline] [scroll-timeline-name:--scrollable] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-			{children}
+	scrollAlign = "nearest",
+}) => {
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: 初期表示時のみ scrollLeft を設定する。マウント後の prop 変化には反応しない（uncontrolled の慣習）
+	useEffect(() => {
+		const container = scrollRef.current;
+		if (!container) return;
+		const target = container.querySelector<HTMLElement>(
+			"[data-initial-scroll]",
+		);
+		if (!target) return;
+		const containerRect = container.getBoundingClientRect();
+		const targetRect = target.getBoundingClientRect();
+		container.scrollLeft = computeScrollLeft(
+			{
+				containerWidth: container.clientWidth,
+				containerScrollLeft: container.scrollLeft,
+				targetLeft: targetRect.left - containerRect.left + container.scrollLeft,
+				targetWidth: targetRect.width,
+			},
+			scrollAlign,
+		);
+	}, []);
+
+	return (
+		<div
+			data-slot="scroll-area"
+			className={cn("relative [timeline-scope:--scrollable]", className)}
+		>
+			<div
+				ref={scrollRef}
+				className="overflow-x-auto [scroll-timeline-axis:inline] [scroll-timeline-name:--scrollable] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+			>
+				{children}
+			</div>
+			<div
+				aria-hidden="true"
+				className={cn(
+					"pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--scrollable]",
+					fadeFrom,
+				)}
+			/>
+			<div
+				aria-hidden="true"
+				className={cn(
+					"pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--scrollable]",
+					fadeFrom,
+				)}
+			/>
 		</div>
-		<div
-			aria-hidden="true"
-			className={cn(
-				"pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--scrollable]",
-				fadeFrom,
-			)}
-		/>
-		<div
-			aria-hidden="true"
-			className={cn(
-				"pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--scrollable]",
-				fadeFrom,
-			)}
-		/>
-	</div>
-);
+	);
+};

--- a/packages/react-components/src/primitives/tabs/tabs.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.tsx
@@ -87,13 +87,13 @@ export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => (
 const TabScrollFadeStart: FC = () => (
 	<div
 		aria-hidden="true"
-		className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-start] [animation-timeline:--tab-scroll]"
+		className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--tab-scroll]"
 	/>
 );
 
 const TabScrollFadeEnd: FC = () => (
 	<div
 		aria-hidden="true"
-		className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-end] [animation-timeline:--tab-scroll]"
+		className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--tab-scroll]"
 	/>
 );

--- a/packages/react-components/src/primitives/tabs/tabs.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.tsx
@@ -87,13 +87,13 @@ export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => (
 const TabScrollFadeStart: FC = () => (
 	<div
 		aria-hidden="true"
-		className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-start] [animation-timeline:--tab-scroll]"
+		className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-start] [animation-timeline:--tab-scroll]"
 	/>
 );
 
 const TabScrollFadeEnd: FC = () => (
 	<div
 		aria-hidden="true"
-		className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:scroll-fade-end] [animation-timeline:--tab-scroll]"
+		className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-end] [animation-timeline:--tab-scroll]"
 	/>
 );

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -285,6 +285,26 @@ body {
 	}
 }
 
+@keyframes tab-scroll-fade-start {
+	0% {
+		opacity: 0;
+	}
+	1%,
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes tab-scroll-fade-end {
+	0%,
+	99% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
 @keyframes scroll-fade-start {
 	0% {
 		opacity: 0;

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -285,7 +285,7 @@ body {
 	}
 }
 
-@keyframes tab-scroll-fade-start {
+@keyframes scroll-fade-start {
 	0% {
 		opacity: 0;
 	}
@@ -295,7 +295,7 @@ body {
 	}
 }
 
-@keyframes tab-scroll-fade-end {
+@keyframes scroll-fade-end {
 	0%,
 	99% {
 		opacity: 1;


### PR DESCRIPTION
# 概要

close #759

`ScrollArea` プリミティブを `packages/react-components/src/primitives/scrollable/` に新規追加する。`TabScrollArea` の実装をベースに Tab 固有の意見を剥がし、背景色を `fadeFrom` prop で外から指定できる汎用 API として提供する。

Tab プリミティブには変更を加えない方針のため、`tabs.tsx` は元の `tab-scroll-fade-*` 参照のまま据え置き、`tailwind-config/tailwind.css` には `scroll-fade-*` keyframes を別名で追加して共存させる。`tab-scroll-fade-*` と `scroll-fade-*` は内容が同一だが、後段の共通化 PR で掃除する前提で一時的に重複を許容する。

## この変更による影響

- `@next-lift/react-components` の利用側: `ScrollArea` をパッケージルートから import 可能になる。Tab を含む既存コンポーネントの API・挙動には変更なし
- `@next-lift/tailwind-config` の利用側: 既存の `tab-scroll-fade-*` keyframes は維持されるため回帰なし。新規に `scroll-fade-*` keyframes が追加される
- 後段で予定している共通化 PR で `tab-scroll-fade-*` を撤去する想定

## CIでチェックできなかった項目

- Storybook で `ScrollArea` の挙動目視確認（スクロール位置に応じたフェード in/out）
- Tab の既存挙動（`TabScrollArea` のフェード）に回帰がないこと

## 補足

- keyframes の重複は本 PR の意図的なスコープ制限。後段の共通化 PR で `tab-scroll-fade-*` を撤去し `scroll-fade-*` に統一する