### PR TITLE
refactor(react-components): tabs から fade 処理を剥がし ScrollArea に統一

### DIFF
--- a/packages/react-components/src/primitives/tabs/tabs.stories.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.stories.tsx
@@ -2,12 +2,13 @@ import { PlusIcon, TrashIcon } from "@heroicons/react/24/solid";
 import type { Meta, StoryObj } from "@storybook/react";
 import { type FC, useState } from "react";
 import { Button } from "../button/button";
+import { ScrollArea } from "../scrollable/scrollable";
 import {
 	TextField,
 	TextFieldInput,
 	TextFieldLabel,
 } from "../text-field/text-field";
-import { Tab, TabList, TabPanel, TabScrollArea, Tabs } from "./tabs";
+import { Tab, TabList, TabPanel, Tabs } from "./tabs";
 
 const meta = {
 	title: "UI/Tabs",
@@ -259,7 +260,7 @@ export const WithScrollableTabs: Story = {
 	],
 	render: () => (
 		<Tabs>
-			<TabScrollArea>
+			<ScrollArea>
 				<TabList aria-label="Day">
 					{longLabelTabs.map((day) => (
 						<Tab key={day.id} id={day.id}>
@@ -267,7 +268,7 @@ export const WithScrollableTabs: Story = {
 						</Tab>
 					))}
 				</TabList>
-			</TabScrollArea>
+			</ScrollArea>
 			{longLabelTabs.map((day) => (
 				<TabPanel key={day.id} id={day.id}>
 					<p>{day.label} の内容</p>
@@ -296,7 +297,7 @@ export const MobileScrollable: Story = {
 	],
 	render: () => (
 		<Tabs>
-			<TabScrollArea>
+			<ScrollArea>
 				<TabList aria-label="Day">
 					{mobileDays.map((day) => (
 						<Tab key={day.id} id={day.id}>
@@ -304,7 +305,7 @@ export const MobileScrollable: Story = {
 						</Tab>
 					))}
 				</TabList>
-			</TabScrollArea>
+			</ScrollArea>
 			{mobileDays.map((day) => (
 				<TabPanel key={day.id} id={day.id}>
 					<p>{day.label} の内容</p>

--- a/packages/react-components/src/primitives/tabs/tabs.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { FC, PropsWithChildren } from "react";
+import type { FC } from "react";
 import {
 	TabList as TabListPrimitive,
 	type TabListProps as TabListPrimitiveProps,
@@ -68,32 +68,5 @@ export const TabPanel: FC<TabPanelPrimitiveProps> = ({
 		data-slot="tab-panel"
 		className={cx("flex-1 text-fg outline-hidden", className)}
 		{...props}
-	/>
-);
-
-export const TabScrollArea: FC<PropsWithChildren> = ({ children }) => (
-	<div
-		data-slot="tab-scroll-area"
-		className="relative [timeline-scope:--tab-scroll]"
-	>
-		<div className="overflow-x-auto [scroll-timeline-axis:inline] [scroll-timeline-name:--tab-scroll] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-			{children}
-		</div>
-		<TabScrollFadeStart />
-		<TabScrollFadeEnd />
-	</div>
-);
-
-const TabScrollFadeStart: FC = () => (
-	<div
-		aria-hidden="true"
-		className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-start] [animation-timeline:--tab-scroll]"
-	/>
-);
-
-const TabScrollFadeEnd: FC = () => (
-	<div
-		aria-hidden="true"
-		className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-overlay to-transparent opacity-0 [animation-fill-mode:both] [animation-name:tab-scroll-fade-end] [animation-timeline:--tab-scroll]"
 	/>
 );

--- a/packages/react-components/src/views/program-detail/index.tsx
+++ b/packages/react-components/src/views/program-detail/index.tsx
@@ -1,12 +1,7 @@
 import type { ComponentProps, FC } from "react";
 import { Heading, Section } from "../../primitives/heading";
-import {
-	Tab,
-	TabList,
-	TabPanel,
-	TabScrollArea,
-	Tabs,
-} from "../../primitives/tabs";
+import { ScrollArea } from "../../primitives/scrollable";
+import { Tab, TabList, TabPanel, Tabs } from "../../primitives/tabs";
 import { CreateDayCard } from "./create-day-card";
 import { ExercisePlanSection } from "./exercise-plan-section";
 import { SetPlanSection } from "./set-plan-section";
@@ -58,7 +53,7 @@ export const ProgramDetail: FC<Props> = ({
 			) : (
 				<Section>
 					<Tabs {...tabsProps}>
-						<TabScrollArea>
+						<ScrollArea>
 							<TabList aria-label="Day">
 								{days.map((day) => (
 									<Tab key={day.id} id={day.id}>
@@ -66,7 +61,7 @@ export const ProgramDetail: FC<Props> = ({
 									</Tab>
 								))}
 							</TabList>
-						</TabScrollArea>
+						</ScrollArea>
 						{days.map((day) => (
 							<TabPanel key={day.id} id={day.id} className="pt-4">
 								<ExercisePlanSection exercisePlans={day.exercisePlans}>

--- a/packages/tailwind-config/tailwind.css
+++ b/packages/tailwind-config/tailwind.css
@@ -285,26 +285,6 @@ body {
 	}
 }
 
-@keyframes tab-scroll-fade-start {
-	0% {
-		opacity: 0;
-	}
-	1%,
-	100% {
-		opacity: 1;
-	}
-}
-
-@keyframes tab-scroll-fade-end {
-	0%,
-	99% {
-		opacity: 1;
-	}
-	100% {
-		opacity: 0;
-	}
-}
-
 @keyframes scroll-fade-start {
 	0% {
 		opacity: 0;


### PR DESCRIPTION
# 概要

`TabScrollArea` は `ScrollArea` プリミティブの先行実装と等価だったため削除し、tabs プリミティブから fade 処理を剥がして `ScrollArea` に統一する。

- `TabScrollArea` を削除し、利用側で `ScrollArea` を直接使う形に揃えた
- tabs プリミティブから fade 処理（`TabScrollFadeStart` / `TabScrollFadeEnd` と `--tab-scroll` timeline）を撤去
- 未使用になった `tab-scroll-fade-start` / `tab-scroll-fade-end` keyframes を `tailwind.css` から削除（`scroll-fade-*` と重複していたもの）

旧 PR #761 のブランチ名が `consistent-pull-request` ワークフローのルールに違反していたため、`refactor/...` プレフィックスで切り直したもの。

## この変更による影響

- ユーザー影響なし。`fadeFrom` のデフォルト値は `overlay` で、削除した `TabScrollArea` の `from-overlay` と一致するため見た目に変化なし
- `@next-lift/react-components` 利用側で `TabScrollArea` を import している箇所は `ScrollArea` に置き換える必要がある。本リポジトリ内では `apps/web` の `program-detail` ビューのみ該当し、本 PR で対応済み

変更ファイル:

- `packages/react-components/src/primitives/tabs/tabs.tsx`
- `packages/react-components/src/primitives/tabs/tabs.stories.tsx`
- `packages/react-components/src/views/program-detail/index.tsx`
- `packages/tailwind-config/tailwind.css`

## CIでチェックできなかった項目

- Storybook の `UI/Tabs > WithScrollableTabs` / `MobileScrollable` でフェード表示が従来通りに見えるかの目視確認
- `ProgramDetail` ビューで Day タブを横スクロールしたときに端のフェードが従来どおり出るかの確認

## 補足

- `pnpm --filter @next-lift/react-components type-check` / `lint`（既存警告のみ）/ `test`（27 passed）はローカルで確認済み