### PR TITLE
ci: PR Push check に Test と Storybook Test ジョブを追加

### DIFF
--- a/.github/workflows/pr-push-check.yml
+++ b/.github/workflows/pr-push-check.yml
@@ -77,3 +77,38 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
+
+  test:
+    name: Test
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Test
+        run: pnpm run test
+
+  storybook-test:
+    name: Storybook Test
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @next-lift/react-components exec playwright install --with-deps chromium
+
+      - name: Run Storybook tests
+        run: pnpm --filter @next-lift/react-components exec vitest run --project storybook

--- a/.github/workflows/pr-push-check.yml
+++ b/.github/workflows/pr-push-check.yml
@@ -92,7 +92,7 @@ jobs:
         uses: ./.github/actions/setup-workspace
 
       - name: Test
-        run: pnpm run test
+        run: pnpm exec turbo test --concurrency=1
 
   storybook-test:
     name: Storybook Test

--- a/.github/workflows/pr-push-check.yml
+++ b/.github/workflows/pr-push-check.yml
@@ -84,6 +84,10 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,8 +95,17 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
 
+      - name: Pull Vercel Environment
+        run: |
+          npx vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
+
       - name: Test
-        run: pnpm exec turbo test --concurrency=1
+        run: |
+          set -a
+          source .vercel/.env.preview.local
+          set +a
+          export APP_ENV="development-ci"
+          pnpm exec turbo test --concurrency=1
 
   storybook-test:
     name: Storybook Test

--- a/turbo.json
+++ b/turbo.json
@@ -36,7 +36,27 @@
 			"dependsOn": ["^type-check"]
 		},
 		"test": {
-			"dependsOn": ["^build"]
+			"dependsOn": ["^build"],
+			"passThroughEnv": [
+				"BETTER_AUTH_URL",
+				"BETTER_AUTH_SECRET",
+				"GOOGLE_CLIENT_ID",
+				"GOOGLE_CLIENT_SECRET",
+				"APPLE_CLIENT_ID",
+				"APPLE_TEAM_ID",
+				"APPLE_KEY_ID",
+				"APPLE_PRIVATE_KEY",
+				"SENTRY_ORG",
+				"SENTRY_PROJECT",
+				"SENTRY_AUTH_TOKEN",
+				"NEXT_PUBLIC_SENTRY_DSN",
+				"NEXT_PUBLIC_BETTER_AUTH_URL",
+				"TURSO_PLATFORM_API_TOKEN",
+				"TURSO_ORGANIZATION",
+				"TURSO_TOKEN_ENCRYPTION_KEY",
+				"APP_ENV",
+				"CI"
+			]
 		},
 		"clean": {
 			"cache": false


### PR DESCRIPTION
# 概要

PR Push check workflow に `Test` と `Storybook Test` ジョブを追加し、CI で安定して走るようにするための周辺修正をまとめる。

## 背景

これまで `pr-push-check.yml` には Build / Type check / Lint しかなく、test (unit / Storybook の play 関数) は CI で実行されていなかった。`chromatic.yml` も `--exit-zero-on-changes` で visual changes があっても exit 0 になる。結果、Storybook の play test が落ちていても CI 全体は pass する状態だった。

別 PR (#756) の作業中に「ローカル test は通るが Chromatic にデプロイされた Storybook で play function が失敗する」ケースに遭遇したのを契機に、CI で test を必須化する。

## 含まれる変更

| commit | 内容 |
|---|---|
| ci: PR Push check に Test と Storybook Test ジョブを追加 | turbo test (unit) と vitest run --project storybook (Storybook play test) の 2 ジョブを新設。Storybook Test は playwright chromium を install してから実行 |
| ci: Test ジョブの turbo concurrency を 1 にして esbuild 競合を回避 | GitHub Actions runner (4GB RAM) で turbo がデフォルト並列度で 9 パッケージの vitest を同時起動すると esbuild の child process pool が write EPIPE で停止する。--concurrency=1 で順次実行 |
| ci: Test ジョブで Vercel から env を pull してから vitest を実行する | Build ジョブと同じ vercel pull + source .vercel/.env.preview.local パターンを Test にも適用。parseEnv (zod) が BETTER_AUTH_SECRET 等の env 未定義で throw する問題を解消 |
| chore(turbo): test タスクに passThroughEnv を追加して env を子プロセスに渡す | turbo の strict env mode により、test タスクの passThroughEnv に列挙されていない env が vitest プロセスに渡らなかった。build タスクと同じ env リストを追加 |

## この変更による影響

### 開発者

- PR ごとの CI 時間が増える (Test +約 52s、Storybook Test +約 1m14s)
- これまで気付けなかった test 失敗 (unit / Storybook play 関数) が CI で検知できるようになる

### パッケージ利用者・エンドユーザー

- 影響なし (CI のみの変更)

## CIでチェックできなかった項目

- (なし、本 PR は CI 設定そのものの変更)

## 補足

- Storybook Test ジョブは pnpm --filter @next-lift/react-components exec vitest run --project storybook で react-components パッケージの Storybook 用 vitest project のみを実行
- --concurrency=1 で test 実行は順次になるが、build/lint/type-check 等の他ジョブはそのまま並列なので全体の CI 時間への影響は限定的
- 経緯メモ: 当初は Test ジョブを 1 つ追加するだけのつもりが、CI 環境固有の問題が 3 段 (esbuild 並列競合 → env 未取得 → turbo strict env) 出てきたため、4 コミットに分かれている