### PR TITLE
feature(react-components): RPE 入力を flex-wrap 折り返しに変更

### DIFF
--- a/packages/react-components/src/views/program-detail/set-plan-row/set-plan-edit-form-fields.tsx
+++ b/packages/react-components/src/views/program-detail/set-plan-row/set-plan-edit-form-fields.tsx
@@ -6,7 +6,6 @@ import {
 	NumberFieldInput,
 	NumberFieldLabel,
 } from "../../../primitives/number-field";
-import { ScrollArea } from "../../../primitives/scrollable";
 import {
 	SingleToggleButtonGroup,
 	ToggleButton,
@@ -71,27 +70,22 @@ export const RpeField: FC<RpeFieldProps> = ({ value, onChange }) => (
 		>
 			RPE
 		</span>
-		<ScrollArea scrollAlign="center">
-			<SingleToggleButtonGroup
-				aria-label="RPE"
-				selectedKey={value === null ? null : value.toString()}
-				onSelectionChange={(key) => onChange(key === null ? null : Number(key))}
-				// NumberField の Group（border 込み 42px）と高さを揃え、Tabs 切替時の
-				// フォーム高さ差を消すために min-h-[2.625rem] を指定。items-center で
-				// ToggleButton 自体（min-h-9 / sm:min-h-8）を垂直中央に置く
-				className="flex w-fit items-center gap-1 min-h-[2.625rem]"
-			>
-				{RPE_OPTIONS.map((rpe) => (
-					<ToggleButton
-						key={rpe}
-						id={rpe.toString()}
-						data-initial-scroll={value === rpe ? "" : undefined}
-					>
-						{rpe}
-					</ToggleButton>
-				))}
-			</SingleToggleButtonGroup>
-		</ScrollArea>
+		<SingleToggleButtonGroup
+			aria-label="RPE"
+			selectedKey={value === null ? null : value.toString()}
+			onSelectionChange={(key) => onChange(key === null ? null : Number(key))}
+			className="flex flex-wrap gap-1.5"
+		>
+			{RPE_OPTIONS.map((rpe) => (
+				<ToggleButton
+					key={rpe}
+					id={rpe.toString()}
+					className="min-h-10 min-w-12 px-3 text-base sm:min-h-10 sm:text-base"
+				>
+					{rpe}
+				</ToggleButton>
+			))}
+		</SingleToggleButtonGroup>
 	</div>
 );
 

--- a/packages/react-components/src/views/program-detail/set-plan-row/set-plan-row-weight-rpe.stories.tsx
+++ b/packages/react-components/src/views/program-detail/set-plan-row/set-plan-row-weight-rpe.stories.tsx
@@ -84,24 +84,3 @@ export const EditRpeInSameTab: Story = {
 		});
 	},
 };
-
-export const RpeCentersOnOpen: Story = {
-	name: "RPE 既選択時に中央スクロールで開く",
-	globals: { viewport: { value: "desktop" } },
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await userEvent.click(
-			canvas.getByRole("button", { name: "ベンチプレス 1セット目を編集" }),
-		);
-		const dialog = await screen.findByRole("dialog");
-		const rpe8 = within(dialog).getByRole("radio", { name: "8" });
-		expect(rpe8).toHaveAttribute("aria-checked", "true");
-		const inner = rpe8.closest<HTMLElement>(".overflow-x-auto");
-		if (inner === null) throw new Error("scroll container not found");
-		const rpeRect = rpe8.getBoundingClientRect();
-		const innerRect = inner.getBoundingClientRect();
-		const rpeCenter = rpeRect.left + rpeRect.width / 2;
-		const innerCenter = innerRect.left + innerRect.width / 2;
-		expect(Math.abs(rpeCenter - innerCenter)).toBeLessThan(8);
-	},
-};


### PR DESCRIPTION
# 概要

RPE 入力 (SetPlanFormDialog 内) を ScrollArea ベースの横スクロールから flex-wrap ベースの折り返し表示に変更し、ToggleButton のタップターゲットを拡大する。

横スクロールでは見えていない選択肢を確認するためにスクロールが必要だったが、折り返し表示にすることで全選択肢が一覧でき、片手で押しやすくなる。

## この変更による影響

**ユーザー影響**: RPE 入力 UI の見た目と挙動が変わる:

- 横一列のスクロール → 2 段の折り返し表示
- ToggleButton が大きくなる (min-h-10 min-w-12 px-3 text-base)
- 選択中の選択肢への初期スクロール処理を撤去（全選択肢が見えているため不要）

**コード影響**: 直前の修正 7e5b8f5（Tabs 切替時の高さ揃え workaround）は ScrollArea 前提だったため不要になり、撤去する。

## CIでチェックできなかった項目

- [ ] モバイルビュー (Drawer) で RPE 折り返しが意図通り 2 段に並ぶか
- [ ] デスクトップビュー (Popover) で同じく折り返し表示が崩れないか
- [ ] Tabs 切替（重量×回数 ↔ 重量×RPE ↔ 回数×RPE）でフォーム全体の高さが大きく変動しないか
- [ ] 既存の Chromatic スナップショットとの視覚的回帰差分の確認

## 補足

- 後続 PR で SetPlanSection 周辺の構造リファクタを予定（このブランチを base にする）