### PR TITLE
feature(react-components): toggle-button-group stories の id を useId 化

### DIFF
--- a/packages/react-components/src/primitives/toggle-button-group/multi-toggle-button-group.stories.tsx
+++ b/packages/react-components/src/primitives/toggle-button-group/multi-toggle-button-group.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { type FC, useId } from "react";
 import { MultiToggleButtonGroup } from "./multi-toggle-button-group";
 import { ToggleButton } from "./toggle-button";
 
@@ -16,14 +17,24 @@ type Story = StoryObj<typeof meta>;
 
 export const TextDecoration: Story = {
 	name: "テキスト装飾（複数選択）",
-	render: () => (
+	render: () => <TextDecorationDemo />,
+};
+
+const TextDecorationDemo: FC = () => {
+	const baseId = useId();
+	const ids = {
+		bold: `${baseId}-bold`,
+		italic: `${baseId}-italic`,
+		underline: `${baseId}-underline`,
+	};
+	return (
 		<MultiToggleButtonGroup
-			defaultSelectedKeys={["bold", "italic"]}
+			defaultSelectedKeys={[ids.bold, ids.italic]}
 			className="flex gap-1"
 		>
-			<ToggleButton id="bold">太字</ToggleButton>
-			<ToggleButton id="italic">斜体</ToggleButton>
-			<ToggleButton id="underline">下線</ToggleButton>
+			<ToggleButton id={ids.bold}>太字</ToggleButton>
+			<ToggleButton id={ids.italic}>斜体</ToggleButton>
+			<ToggleButton id={ids.underline}>下線</ToggleButton>
 		</MultiToggleButtonGroup>
-	),
+	);
 };

--- a/packages/react-components/src/primitives/toggle-button-group/single-toggle-button-group.stories.tsx
+++ b/packages/react-components/src/primitives/toggle-button-group/single-toggle-button-group.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { type FC, useId } from "react";
 import { SingleToggleButtonGroup } from "./single-toggle-button-group";
 import { ToggleButton } from "./toggle-button";
 
@@ -32,13 +33,26 @@ export const NumberOptions: Story = {
 
 export const StringOptions: Story = {
 	name: "文字列オプション（テキスト配置）",
-	render: () => (
-		<SingleToggleButtonGroup defaultSelectedKey="center" className="flex gap-1">
-			<ToggleButton id="left">左</ToggleButton>
-			<ToggleButton id="center">中央</ToggleButton>
-			<ToggleButton id="right">右</ToggleButton>
+	render: () => <StringOptionsDemo />,
+};
+
+const StringOptionsDemo: FC = () => {
+	const baseId = useId();
+	const ids = {
+		left: `${baseId}-left`,
+		center: `${baseId}-center`,
+		right: `${baseId}-right`,
+	};
+	return (
+		<SingleToggleButtonGroup
+			defaultSelectedKey={ids.center}
+			className="flex gap-1"
+		>
+			<ToggleButton id={ids.left}>左</ToggleButton>
+			<ToggleButton id={ids.center}>中央</ToggleButton>
+			<ToggleButton id={ids.right}>右</ToggleButton>
 		</SingleToggleButtonGroup>
-	),
+	);
 };
 
 export const NoneSelected: Story = {


### PR DESCRIPTION
# 概要

`single-toggle-button-group.stories.tsx` / `multi-toggle-button-group.stories.tsx` の `ToggleButton` の `id` をハードコード文字列 (`"bold"` / `"italic"` 等) から `useId()` 生成に切り替える。Biome の `useUniqueElementIds` 警告を解消する。

## この変更による影響

**ユーザー影響**: なし（Storybook 内のストーリーのみ。本体コンポーネントは変更なし）

**生成 HTML への影響**: ToggleButton の `id` 属性が静的文字列から `useId()` 由来の動的 id に変わる。同じストーリーが Storybook ページ内で複数描画されたとき DOM id が衝突しなくなる。

## CIでチェックできなかった項目

- [ ] Storybook で当該ストーリー（TextDecoration / StringOptions）が従来通り選択状態で表示されるか

## 補足

- 変更内容:
  - 2 ストーリーの `render` を `<XxxDemo />` という FC に切り出し、`useId()` を呼べる形に
  - `id` / `defaultSelectedKey(s)` を `useId()` ベースの id に置換