### PR TITLE
refactor(react-components): primitives/popover/ を新設し Popover シェルの重複を集約

### DIFF
--- a/packages/react-components/src/primitives/combo-box/combo-box.tsx
+++ b/packages/react-components/src/primitives/combo-box/combo-box.tsx
@@ -17,13 +17,13 @@ import {
 	ListBoxItem as ListBoxItemPrimitive,
 	type ListBoxItemProps,
 	type ListBoxProps,
-	Popover,
 	type PopoverProps,
 	Text,
 	type TextProps,
 } from "react-aria-components";
 import { cx } from "../../libs/primitive";
 import { cn } from "../../libs/utils";
+import { PopoverContent } from "../popover";
 
 export const ComboBox = <T extends object>({
 	className,
@@ -104,13 +104,10 @@ export const ComboBoxList = <T extends object>({
 	offset = 4,
 	...props
 }: ComboBoxListProps<T>) => (
-	<Popover
+	<PopoverContent
 		className={cn(
 			"min-w-(--trigger-width) origin-(--trigger-anchor-point)",
 			"max-h-72 overflow-hidden",
-			"rounded-lg border border-border bg-overlay text-overlay-fg shadow-lg outline-hidden",
-			"entering:fade-in entering:animate-in entering:duration-150",
-			"exiting:fade-out exiting:animate-out exiting:duration-100",
 		)}
 		offset={offset}
 		{...(placement !== undefined ? { placement } : {})}
@@ -122,7 +119,7 @@ export const ComboBoxList = <T extends object>({
 			)}
 			{...props}
 		/>
-	</Popover>
+	</PopoverContent>
 );
 
 export const ComboBoxItem = <T extends object>({

--- a/packages/react-components/src/primitives/index.ts
+++ b/packages/react-components/src/primitives/index.ts
@@ -10,6 +10,7 @@ export * from "./main";
 export * from "./menu";
 export * from "./modal";
 export * from "./number-field";
+export * from "./popover";
 export * from "./scrollable";
 export * from "./tabs";
 export * from "./text-field";

--- a/packages/react-components/src/primitives/menu/menu.tsx
+++ b/packages/react-components/src/primitives/menu/menu.tsx
@@ -7,7 +7,6 @@ import {
 	Menu as MenuPrimitive,
 	type MenuProps as MenuPrimitiveProps,
 	MenuTrigger as MenuTriggerPrimitive,
-	Popover,
 	type PopoverProps,
 	Separator,
 	type SeparatorProps,
@@ -15,6 +14,7 @@ import {
 import { tv, type VariantProps } from "tailwind-variants";
 import { cx } from "../../libs/primitive";
 import { cn } from "../../libs/utils";
+import { PopoverContent } from "../popover";
 
 export const MenuTrigger = MenuTriggerPrimitive;
 
@@ -27,13 +27,8 @@ export const Menu = <T extends object>({
 	offset = 4,
 	...props
 }: MenuProps<T>) => (
-	<Popover
-		className={cn(
-			"min-w-(--trigger-width) max-w-xs origin-(--trigger-anchor-point)",
-			"rounded-lg border border-border bg-overlay text-overlay-fg shadow-lg outline-hidden",
-			"entering:fade-in entering:animate-in entering:duration-150",
-			"exiting:fade-out exiting:animate-out exiting:duration-100",
-		)}
+	<PopoverContent
+		className="min-w-(--trigger-width) max-w-xs origin-(--trigger-anchor-point)"
 		offset={offset}
 		{...(placement !== undefined ? { placement } : {})}
 	>
@@ -44,7 +39,7 @@ export const Menu = <T extends object>({
 			)}
 			{...props}
 		/>
-	</Popover>
+	</PopoverContent>
 );
 
 const menuItemStyles = tv({

--- a/packages/react-components/src/primitives/popover/index.ts
+++ b/packages/react-components/src/primitives/popover/index.ts
@@ -1,0 +1,1 @@
+export * from "./popover";

--- a/packages/react-components/src/primitives/popover/popover.stories.tsx
+++ b/packages/react-components/src/primitives/popover/popover.stories.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dialog } from "react-aria-components";
+import { Button } from "../button";
+import { Popover, PopoverContent } from "./popover";
+
+const meta = {
+	title: "UI/Popover",
+	component: Popover,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: { children: null },
+	render: () => (
+		<Popover>
+			<Button>ポップオーバーを開く</Button>
+			<PopoverContent placement="bottom">
+				<Dialog className="p-4 outline-hidden" aria-label="ポップオーバー">
+					<p className="text-fg text-sm">
+						Popover の基本利用例。シェルは primitive 側に内蔵されている。
+					</p>
+				</Dialog>
+			</PopoverContent>
+		</Popover>
+	),
+};
+
+export const PlacementTop: Story = {
+	args: { children: null },
+	name: "配置: top",
+	render: () => (
+		<Popover>
+			<Button>上に表示</Button>
+			<PopoverContent placement="top">
+				<Dialog className="p-4 outline-hidden" aria-label="上配置">
+					<p className="text-fg text-sm">placement="top"</p>
+				</Dialog>
+			</PopoverContent>
+		</Popover>
+	),
+};
+
+export const PlacementLeft: Story = {
+	args: { children: null },
+	name: "配置: left",
+	render: () => (
+		<Popover>
+			<Button>左に表示</Button>
+			<PopoverContent placement="left">
+				<Dialog className="p-4 outline-hidden" aria-label="左配置">
+					<p className="text-fg text-sm">placement="left"</p>
+				</Dialog>
+			</PopoverContent>
+		</Popover>
+	),
+};
+
+export const PlacementRight: Story = {
+	args: { children: null },
+	name: "配置: right",
+	render: () => (
+		<Popover>
+			<Button>右に表示</Button>
+			<PopoverContent placement="right">
+				<Dialog className="p-4 outline-hidden" aria-label="右配置">
+					<p className="text-fg text-sm">placement="right"</p>
+				</Dialog>
+			</PopoverContent>
+		</Popover>
+	),
+};
+
+export const WithMaxWidth: Story = {
+	args: { children: null },
+	name: "幅制約付き (フォーム想定)",
+	render: () => (
+		<Popover>
+			<Button>フォームを開く</Button>
+			<PopoverContent
+				placement="bottom end"
+				className="max-w-[min(22rem,calc(100vw-2rem))]"
+			>
+				<Dialog className="w-88 p-3 outline-hidden" aria-label="フォーム">
+					<p className="text-fg text-sm">
+						consumer が className で幅制約を上書きできる。
+					</p>
+				</Dialog>
+			</PopoverContent>
+		</Popover>
+	),
+};

--- a/packages/react-components/src/primitives/popover/popover.tsx
+++ b/packages/react-components/src/primitives/popover/popover.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { FC } from "react";
+import {
+	DialogTrigger as DialogTriggerPrimitive,
+	Popover as PopoverPrimitive,
+	type PopoverProps as PopoverPrimitiveProps,
+} from "react-aria-components";
+import { cn } from "../../libs/utils";
+
+export const Popover = DialogTriggerPrimitive;
+
+type PopoverContentProps = Omit<PopoverPrimitiveProps, "className"> & {
+	className?: string;
+};
+
+export const PopoverContent: FC<PopoverContentProps> = ({
+	className,
+	...props
+}) => (
+	<PopoverPrimitive
+		className={cn(
+			"rounded-lg border border-border bg-overlay text-overlay-fg shadow-lg outline-hidden",
+			"entering:fade-in entering:animate-in entering:duration-150",
+			"exiting:fade-out exiting:animate-out exiting:duration-100",
+			className,
+		)}
+		{...props}
+	/>
+);

--- a/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/set-plan-form-dialog-popover.tsx
+++ b/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/set-plan-form-dialog-popover.tsx
@@ -2,9 +2,9 @@
 
 import { CheckIcon } from "@heroicons/react/24/outline";
 import type { FC, PropsWithChildren, ReactNode, SubmitEvent } from "react";
-import { Dialog, DialogTrigger, Popover } from "react-aria-components";
-import { cn } from "../../../../libs/utils";
+import { Dialog } from "react-aria-components";
 import { Button } from "../../../../primitives/button";
+import { Popover, PopoverContent } from "../../../../primitives/popover";
 
 type Props = PropsWithChildren<{
 	title: string;
@@ -29,16 +29,11 @@ export const SetPlanFormDialogPopover: FC<Props> = ({
 		onCommit();
 	};
 	return (
-		<DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
+		<Popover isOpen={isOpen} onOpenChange={onOpenChange}>
 			{trigger}
-			<Popover
+			<PopoverContent
 				placement="bottom end"
-				className={cn(
-					"max-w-[min(22rem,calc(100vw-2rem))]",
-					"rounded-lg border border-border bg-overlay text-overlay-fg shadow-lg outline-hidden",
-					"entering:fade-in entering:animate-in entering:duration-150",
-					"exiting:fade-out exiting:animate-out exiting:duration-100",
-				)}
+				className="max-w-[min(22rem,calc(100vw-2rem))]"
 			>
 				<Dialog className="w-88 p-3 outline-hidden" aria-label={title}>
 					<form
@@ -61,7 +56,7 @@ export const SetPlanFormDialogPopover: FC<Props> = ({
 						</div>
 					</form>
 				</Dialog>
-			</Popover>
-		</DialogTrigger>
+			</PopoverContent>
+		</Popover>
 	);
 };


### PR DESCRIPTION
# 概要

closes #796

`primitives/popover/` を新設し、Popover シェル（パネル装飾 + 入退場アニメ）を内蔵した薄い primitive を追加した（`Popover` / `PopoverContent`）。
Menu / ComboBox / SetPlanFormDialogPopover の 3 箇所で重複していたシェルクラスを集約し、トーン変更時の修正箇所を 1 箇所に絞った。ケース固有のクラス（`min-w-(--trigger-width)` / `max-w-xs` / `max-h-72` / `max-w-[min(22rem,...)]` / `origin-(--trigger-anchor-point)`）は consumer 側で `className` 経由で渡す形に揃えた。

`PopoverTitle` は現状の利用箇所で使われていないため、YAGNI に従い見送り（drawer の `DrawerTitle` と粒度を揃えるなら将来追加でよい）。

## この変更による影響

- 公開 API に `Popover` / `PopoverContent` が追加される（破壊的変更なし、追加のみ）
- 既存の Menu / ComboBox / set-plan-section の Popover 描画は視覚的に同一（同じシェルクラスを集約し、ケース固有クラスは consumer から渡している）
- 今後、新規に Popover を使う場合は `react-aria-components` の `Popover` ではなく `@next-lift/react-components` の `Popover` / `PopoverContent` を使う

## CIでチェックできなかった項目

- Storybook で以下の見た目が変わっていないことを視覚確認
  - Menu（`UI/Menu`）
  - ComboBox（`UI/ComboBox`）
  - set-plan-section の Popover（デスクトップ幅でセット計画編集）

## 補足

- `pnpm --filter @next-lift/react-components type-check` / `lint` / `test` / `build-storybook` はローカルでパス済み
- Intent UI の `@intentui/popover` テンプレートを起点に書き起こしたが、`OverlayArrow` / `--gutter` / `--popover-radius` / `ring drop-shadow-xl` 等の意見は剥がし、`drawer` / `modal` と同じ温度感（`shadow-lg` + `border` + フェードのみ）に寄せた
- `set-plan-popover.tsx` というファイルは issue 本文では言及されているが、実体は `set-plan-form-dialog/set-plan-form-dialog-popover.tsx` だったのでこちらを書き換えた

🤖 Generated with [Claude Code](https://claude.com/claude-code)