### PR TITLE
refactor: フォームラベルを Label primitive に集約

### DIFF
--- a/packages/react-components/src/primitives/combo-box/combo-box.stories.tsx
+++ b/packages/react-components/src/primitives/combo-box/combo-box.stories.tsx
@@ -2,13 +2,13 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useMemo, useState } from "react";
 import type { Key } from "react-aria-components";
 import { expect, userEvent, waitFor, within } from "storybook/test";
+import { Label } from "../label/label";
 import {
 	ComboBox,
 	ComboBoxDescription,
 	ComboBoxError,
 	ComboBoxInput,
 	ComboBoxItem,
-	ComboBoxLabel,
 	ComboBoxList,
 } from "./combo-box";
 
@@ -47,7 +47,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	render: () => (
 		<ComboBox aria-label="種目を選択">
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxList items={exercises}>
 				{(item) => <ComboBoxItem id={item.id}>{item.name}</ComboBoxItem>}
@@ -59,7 +59,7 @@ export const Default: Story = {
 export const WithDescription: Story = {
 	render: () => (
 		<ComboBox>
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxDescription>
 				一覧から選ぶか、入力して絞り込めます
@@ -75,7 +75,7 @@ export const WithDefaultSelection: Story = {
 	name: "選択済み",
 	render: () => (
 		<ComboBox defaultValue="squat">
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxList items={exercises}>
 				{(item) => <ComboBoxItem id={item.id}>{item.name}</ComboBoxItem>}
@@ -88,7 +88,7 @@ export const Empty: Story = {
 	name: "0件 (まだ種目未登録)",
 	render: () => (
 		<ComboBox>
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxList<{ id: string; name: string }>
 				items={[]}
@@ -108,7 +108,7 @@ export const NoMatches: Story = {
 	name: "検索結果なし",
 	render: () => (
 		<ComboBox defaultInputValue="存在しない種目">
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxList
 				items={exercises}
@@ -127,7 +127,7 @@ export const NoMatches: Story = {
 export const Required: Story = {
 	render: () => (
 		<ComboBox isRequired>
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxList items={exercises}>
 				{(item) => <ComboBoxItem id={item.id}>{item.name}</ComboBoxItem>}
@@ -139,7 +139,7 @@ export const Required: Story = {
 export const Invalid: Story = {
 	render: () => (
 		<ComboBox isInvalid>
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索" />
 			<ComboBoxError>種目を選択してください</ComboBoxError>
 			<ComboBoxList items={exercises}>
@@ -152,7 +152,7 @@ export const Invalid: Story = {
 export const Disabled: Story = {
 	render: () => (
 		<ComboBox isDisabled defaultInputValue="ベンチプレス">
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput />
 			<ComboBoxList items={exercises}>
 				{(item) => <ComboBoxItem id={item.id}>{item.name}</ComboBoxItem>}
@@ -208,7 +208,7 @@ const CreateNewOptionDemo = () => {
 			onChange={onChange}
 			allowsCustomValue
 		>
-			<ComboBoxLabel>種目</ComboBoxLabel>
+			<Label>種目</Label>
 			<ComboBoxInput placeholder="種目名で検索 / 新規登録" />
 			<ComboBoxDescription>
 				一致する種目がなければ「<strong>○○を登録する</strong>」が候補に出ます

--- a/packages/react-components/src/primitives/combo-box/combo-box.tsx
+++ b/packages/react-components/src/primitives/combo-box/combo-box.tsx
@@ -11,8 +11,6 @@ import {
 	Group,
 	Input as InputPrimitive,
 	type InputProps,
-	Label as LabelPrimitive,
-	type LabelProps,
 	ListBox,
 	ListBoxItem as ListBoxItemPrimitive,
 	type ListBoxItemProps,
@@ -38,19 +36,6 @@ export const ComboBox = <T extends object>({
 			"[&>[slot=description]+[data-slot=control]]:mt-2",
 			"[&>[data-slot=control]+[slot=description]]:mt-2",
 			"[&>[data-slot=control]+[role=alert]]:mt-2",
-			"in-disabled:opacity-50",
-			className,
-		)}
-		{...props}
-	/>
-);
-
-export const ComboBoxLabel: FC<LabelProps> = ({ className, ...props }) => (
-	<LabelPrimitive
-		data-slot="label"
-		className={cn(
-			"block select-none font-medium text-base/6 text-fg sm:text-sm/6",
-			"in-data-[required=true]:after:ml-1.5 in-data-[required=true]:after:text-danger-subtle-fg in-data-[required=true]:after:content-['*']",
 			"in-disabled:opacity-50",
 			className,
 		)}

--- a/packages/react-components/src/primitives/index.ts
+++ b/packages/react-components/src/primitives/index.ts
@@ -5,6 +5,7 @@ export * from "./drawer";
 export * from "./error-alert";
 export * from "./gym-context";
 export * from "./heading";
+export * from "./label";
 export * from "./link";
 export * from "./main";
 export * from "./menu";

--- a/packages/react-components/src/primitives/label/index.ts
+++ b/packages/react-components/src/primitives/label/index.ts
@@ -1,0 +1,1 @@
+export * from "./label";

--- a/packages/react-components/src/primitives/label/label.stories.tsx
+++ b/packages/react-components/src/primitives/label/label.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NumberField, NumberFieldInput } from "../number-field/number-field";
+import { Label } from "./label";
+
+const meta = {
+	title: "UI/Label",
+	component: Label,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+	decorators: [
+		(Story) => (
+			<div className="w-80">
+				<Story />
+			</div>
+		),
+	],
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		children: "重量",
+	},
+};
+
+export const Required: Story = {
+	name: "親の data-required で * が付く",
+	render: () => (
+		<NumberField isRequired>
+			<Label>重量</Label>
+			<NumberFieldInput />
+		</NumberField>
+	),
+};
+
+export const Disabled: Story = {
+	name: "親の disabled で透明度が下がる",
+	render: () => (
+		<NumberField isDisabled defaultValue={60}>
+			<Label>重量</Label>
+			<NumberFieldInput />
+		</NumberField>
+	),
+};

--- a/packages/react-components/src/primitives/label/label.tsx
+++ b/packages/react-components/src/primitives/label/label.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type { FC } from "react";
+import {
+	Label as LabelPrimitive,
+	type LabelProps,
+} from "react-aria-components";
+import { cn } from "../../libs/utils";
+
+export const Label: FC<LabelProps> = ({ className, ...props }) => (
+	<LabelPrimitive
+		data-slot="label"
+		className={cn(
+			"block select-none font-medium text-base/6 text-fg sm:text-sm/6",
+			"in-data-[required=true]:after:ml-1.5 in-data-[required=true]:after:text-danger-subtle-fg in-data-[required=true]:after:content-['*']",
+			"in-disabled:opacity-50",
+			className,
+		)}
+		{...props}
+	/>
+);

--- a/packages/react-components/src/primitives/number-field/number-field.stories.tsx
+++ b/packages/react-components/src/primitives/number-field/number-field.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Label } from "../label/label";
 import {
 	NumberField,
 	NumberFieldDescription,
 	NumberFieldError,
 	NumberFieldInput,
-	NumberFieldLabel,
 } from "./number-field";
 
 const meta = {
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	render: () => (
 		<NumberField defaultValue={10}>
-			<NumberFieldLabel>回数</NumberFieldLabel>
+			<Label>回数</Label>
 			<NumberFieldInput />
 		</NumberField>
 	),
@@ -38,7 +38,7 @@ export const Default: Story = {
 export const WithDescription: Story = {
 	render: () => (
 		<NumberField defaultValue={60} step={2.5}>
-			<NumberFieldLabel>重量</NumberFieldLabel>
+			<Label>重量</Label>
 			<NumberFieldInput />
 			<NumberFieldDescription>
 				+/- ボタンで 2.5kg ずつ調整
@@ -51,7 +51,7 @@ export const WeightWithUnitLabel: Story = {
 	name: "重量 (kg, step=2.5、単位は外側ラベルで表示)",
 	render: () => (
 		<NumberField defaultValue={60} step={2.5} minValue={0}>
-			<NumberFieldLabel>重量 (kg)</NumberFieldLabel>
+			<Label>重量 (kg)</Label>
 			<NumberFieldInput />
 			<NumberFieldDescription>
 				単位はラベルに含めて、入力欄は数値だけにする
@@ -65,7 +65,7 @@ export const WeightWithUnitSuffix: Story = {
 	render: () => (
 		<div className="flex items-end gap-2">
 			<NumberField defaultValue={60} step={2.5} minValue={0}>
-				<NumberFieldLabel>重量</NumberFieldLabel>
+				<Label>重量</Label>
 				<NumberFieldInput />
 			</NumberField>
 			<span className="pb-2 text-fg text-sm">kg</span>
@@ -77,7 +77,7 @@ export const WeightLbsWithUnitLabel: Story = {
 	name: "重量 (lbs, step=5、単位はラベルで表示)",
 	render: () => (
 		<NumberField defaultValue={135} step={5} minValue={0}>
-			<NumberFieldLabel>重量 (lbs)</NumberFieldLabel>
+			<Label>重量 (lbs)</Label>
 			<NumberFieldInput />
 		</NumberField>
 	),
@@ -87,7 +87,7 @@ export const Reps: Story = {
 	name: "回数 (step=1)",
 	render: () => (
 		<NumberField defaultValue={10} step={1} minValue={0}>
-			<NumberFieldLabel>回数</NumberFieldLabel>
+			<Label>回数</Label>
 			<NumberFieldInput />
 			<NumberFieldDescription>1 回ずつ調整</NumberFieldDescription>
 		</NumberField>
@@ -98,7 +98,7 @@ export const WithMinMax: Story = {
 	name: "min / max あり",
 	render: () => (
 		<NumberField defaultValue={5} minValue={0} maxValue={10}>
-			<NumberFieldLabel>セット数</NumberFieldLabel>
+			<Label>セット数</Label>
 			<NumberFieldInput />
 			<NumberFieldDescription>0〜10 の範囲で入力</NumberFieldDescription>
 		</NumberField>
@@ -108,7 +108,7 @@ export const WithMinMax: Story = {
 export const Required: Story = {
 	render: () => (
 		<NumberField isRequired>
-			<NumberFieldLabel>重量</NumberFieldLabel>
+			<Label>重量</Label>
 			<NumberFieldInput />
 		</NumberField>
 	),
@@ -117,7 +117,7 @@ export const Required: Story = {
 export const Invalid: Story = {
 	render: () => (
 		<NumberField isInvalid defaultValue={-10} minValue={0}>
-			<NumberFieldLabel>重量</NumberFieldLabel>
+			<Label>重量</Label>
 			<NumberFieldInput />
 			<NumberFieldError>0 以上の値を入力してください</NumberFieldError>
 		</NumberField>
@@ -127,7 +127,7 @@ export const Invalid: Story = {
 export const Disabled: Story = {
 	render: () => (
 		<NumberField isDisabled defaultValue={60}>
-			<NumberFieldLabel>重量</NumberFieldLabel>
+			<Label>重量</Label>
 			<NumberFieldInput />
 			<NumberFieldDescription>変更できません</NumberFieldDescription>
 		</NumberField>
@@ -137,7 +137,7 @@ export const Disabled: Story = {
 export const ReadOnly: Story = {
 	render: () => (
 		<NumberField isReadOnly defaultValue={60}>
-			<NumberFieldLabel>重量</NumberFieldLabel>
+			<Label>重量</Label>
 			<NumberFieldInput />
 		</NumberField>
 	),
@@ -146,7 +146,7 @@ export const ReadOnly: Story = {
 export const Empty: Story = {
 	render: () => (
 		<NumberField>
-			<NumberFieldLabel>重量</NumberFieldLabel>
+			<Label>重量</Label>
 			<NumberFieldInput placeholder="未入力" />
 			<NumberFieldDescription>
 				値未入力 (paramsなし) のセット計画相当

--- a/packages/react-components/src/primitives/number-field/number-field.tsx
+++ b/packages/react-components/src/primitives/number-field/number-field.tsx
@@ -10,8 +10,6 @@ import {
 	Group,
 	Input as InputPrimitive,
 	type InputProps,
-	Label as LabelPrimitive,
-	type LabelProps,
 	NumberField as NumberFieldPrimitive,
 	type NumberFieldProps as NumberFieldPrimitiveProps,
 	Text,
@@ -33,19 +31,6 @@ export const NumberField: FC<NumberFieldPrimitiveProps> = ({
 			"[&>[slot=description]+[data-slot=control]]:mt-2",
 			"[&>[data-slot=control]+[slot=description]]:mt-2",
 			"[&>[data-slot=control]+[role=alert]]:mt-2",
-			"in-disabled:opacity-50",
-			className,
-		)}
-		{...props}
-	/>
-);
-
-export const NumberFieldLabel: FC<LabelProps> = ({ className, ...props }) => (
-	<LabelPrimitive
-		data-slot="label"
-		className={cn(
-			"block select-none font-medium text-base/6 text-fg sm:text-sm/6",
-			"in-data-[required=true]:after:ml-1.5 in-data-[required=true]:after:text-danger-subtle-fg in-data-[required=true]:after:content-['*']",
 			"in-disabled:opacity-50",
 			className,
 		)}

--- a/packages/react-components/src/primitives/tabs/tabs.stories.tsx
+++ b/packages/react-components/src/primitives/tabs/tabs.stories.tsx
@@ -2,12 +2,9 @@ import { PlusIcon, TrashIcon } from "@heroicons/react/24/solid";
 import type { Meta, StoryObj } from "@storybook/react";
 import { type FC, useState } from "react";
 import { Button } from "../button/button";
+import { Label } from "../label/label";
 import { ScrollArea } from "../scrollable/scrollable";
-import {
-	TextField,
-	TextFieldInput,
-	TextFieldLabel,
-} from "../text-field/text-field";
+import { TextField, TextFieldInput } from "../text-field/text-field";
 import { Tab, TabList, TabPanel, Tabs } from "./tabs";
 
 const meta = {
@@ -188,7 +185,7 @@ const EditFromPanelDemo: FC = () => {
 						value={item.label}
 						onChange={(value) => handleChange(item.id, value)}
 					>
-						<TextFieldLabel>ラベル</TextFieldLabel>
+						<Label>ラベル</Label>
 						<TextFieldInput />
 					</TextField>
 				</TabPanel>

--- a/packages/react-components/src/primitives/text-field/text-field.stories.tsx
+++ b/packages/react-components/src/primitives/text-field/text-field.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Label } from "../label/label";
 import {
 	TextField,
 	TextFieldDescription,
 	TextFieldError,
 	TextFieldInput,
-	TextFieldLabel,
 } from "./text-field";
 
 const meta = {
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	render: () => (
 		<TextField>
-			<TextFieldLabel>プログラム名</TextFieldLabel>
+			<Label>プログラム名</Label>
 			<TextFieldInput placeholder="例: 上半身" />
 		</TextField>
 	),
@@ -38,7 +38,7 @@ export const Default: Story = {
 export const WithDescription: Story = {
 	render: () => (
 		<TextField>
-			<TextFieldLabel>プログラム名</TextFieldLabel>
+			<Label>プログラム名</Label>
 			<TextFieldInput placeholder="例: 上半身" />
 			<TextFieldDescription>
 				あとから種目や Day を追加できます
@@ -50,7 +50,7 @@ export const WithDescription: Story = {
 export const Required: Story = {
 	render: () => (
 		<TextField isRequired>
-			<TextFieldLabel>プログラム名</TextFieldLabel>
+			<Label>プログラム名</Label>
 			<TextFieldInput placeholder="例: 上半身" />
 		</TextField>
 	),
@@ -59,7 +59,7 @@ export const Required: Story = {
 export const Invalid: Story = {
 	render: () => (
 		<TextField isInvalid>
-			<TextFieldLabel>プログラム名</TextFieldLabel>
+			<Label>プログラム名</Label>
 			<TextFieldInput />
 			<TextFieldError>プログラム名を入力してください</TextFieldError>
 		</TextField>
@@ -69,7 +69,7 @@ export const Invalid: Story = {
 export const WithValidation: Story = {
 	render: () => (
 		<TextField isRequired>
-			<TextFieldLabel>プログラム名</TextFieldLabel>
+			<Label>プログラム名</Label>
 			<TextFieldInput />
 			<TextFieldError>
 				{({ validationDetails }) =>
@@ -83,7 +83,7 @@ export const WithValidation: Story = {
 export const Disabled: Story = {
 	render: () => (
 		<TextField isDisabled>
-			<TextFieldLabel>プログラム名</TextFieldLabel>
+			<Label>プログラム名</Label>
 			<TextFieldInput defaultValue="上半身" />
 			<TextFieldDescription>変更できません</TextFieldDescription>
 		</TextField>
@@ -93,7 +93,7 @@ export const Disabled: Story = {
 export const ReadOnly: Story = {
 	render: () => (
 		<TextField isReadOnly>
-			<TextFieldLabel>プログラム名</TextFieldLabel>
+			<Label>プログラム名</Label>
 			<TextFieldInput defaultValue="上半身" />
 		</TextField>
 	),

--- a/packages/react-components/src/primitives/text-field/text-field.tsx
+++ b/packages/react-components/src/primitives/text-field/text-field.tsx
@@ -6,8 +6,6 @@ import {
 	type FieldErrorProps,
 	Input as InputPrimitive,
 	type InputProps,
-	Label as LabelPrimitive,
-	type LabelProps,
 	Text,
 	TextField as TextFieldPrimitive,
 	type TextFieldProps as TextFieldPrimitiveProps,
@@ -29,19 +27,6 @@ export const TextField: FC<TextFieldPrimitiveProps> = ({
 			"[&>[slot=description]+[data-slot=control]]:mt-2",
 			"[&>[data-slot=control]+[slot=description]]:mt-2",
 			"[&>[data-slot=control]+[role=alert]]:mt-2",
-			"in-disabled:opacity-50",
-			className,
-		)}
-		{...props}
-	/>
-);
-
-export const TextFieldLabel: FC<LabelProps> = ({ className, ...props }) => (
-	<LabelPrimitive
-		data-slot="label"
-		className={cn(
-			"block select-none font-medium text-base/6 text-fg sm:text-sm/6",
-			"in-data-[required=true]:after:ml-1.5 in-data-[required=true]:after:text-danger-subtle-fg in-data-[required=true]:after:content-['*']",
 			"in-disabled:opacity-50",
 			className,
 		)}

--- a/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/reps-field.tsx
+++ b/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/reps-field.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { FC } from "react";
+import { Label } from "../../../../primitives/label";
 import {
 	NumberField,
 	NumberFieldInput,
-	NumberFieldLabel,
 } from "../../../../primitives/number-field";
 import { fieldLayout } from "./field-layout";
 
@@ -23,7 +23,7 @@ export const RepsField: FC<Props> = ({ value, onChange }) => (
 		minValue={0}
 		className={fieldLayout}
 	>
-		<NumberFieldLabel>回数</NumberFieldLabel>
+		<Label>回数</Label>
 		<NumberFieldInput />
 	</NumberField>
 );

--- a/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/rpe-field.tsx
+++ b/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/rpe-field.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { FC } from "react";
+import { Label } from "../../../../primitives/label";
 import {
 	SingleToggleButtonGroup,
 	ToggleButton,
@@ -14,13 +15,7 @@ type Props = {
 
 export const RpeField: FC<Props> = ({ value, onChange }) => (
 	<div className={fieldLayout}>
-		{/* TODO(#799): NumberFieldLabel と同じ base styling を手書きでコピーしている。Label primitive 新設時に置き換える */}
-		<span
-			data-slot="label"
-			className="block select-none font-medium text-base/6 text-fg sm:text-sm/6"
-		>
-			RPE
-		</span>
+		<Label>RPE</Label>
 		<SingleToggleButtonGroup
 			aria-label="RPE"
 			selectedKey={value === null ? null : value.toString()}

--- a/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/weight-field.tsx
+++ b/packages/react-components/src/views/program-detail/set-plan-section/set-plan-form-dialog/weight-field.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { FC } from "react";
+import { Label } from "../../../../primitives/label";
 import {
 	NumberField,
 	NumberFieldInput,
-	NumberFieldLabel,
 } from "../../../../primitives/number-field";
 import type { WeightUnit } from "../../weight-unit";
 import { fieldLayout } from "./field-layout";
@@ -31,7 +31,7 @@ export const WeightField: FC<Props> = ({
 		minValue={0}
 		className={fieldLayout}
 	>
-		<NumberFieldLabel>{`重量 (${weightUnit})`}</NumberFieldLabel>
+		<Label>{`重量 (${weightUnit})`}</Label>
 		<NumberFieldInput />
 	</NumberField>
 );


### PR DESCRIPTION
# 概要

`NumberFieldLabel` / `ComboBoxLabel` / `TextFieldLabel` の 3 つが同一の styling を持ち、`ToggleButtonGroup` を使う `RpeField` からは再利用できず生 `<span data-slot="label">` を手書きでコピーしていた状況を解消する。

新たに `primitives/label/` を新設して 4 箇所の重複を 1 つの `Label` primitive に集約した。

close #799

## この変更による影響

- ライブラリ利用側: `NumberFieldLabel` / `ComboBoxLabel` / `TextFieldLabel` を削除し `Label` に統一。今後ラベルの見た目を変えるときは `primitives/label/label.tsx` の 1 箇所を直すだけで済む
- エンドユーザー: 影響なし（生成 HTML / styling は不変）

## CIでチェックできなかった項目

- Storybook の Label / NumberField / ComboBox / TextField / Tabs ストーリーでラベル表示に差分が出ないことの目視確認

## 補足

`grep 'data-slot="label"' packages/react-components/src` で残存箇所が新設 primitive 1 件のみであることを確認済み。