### PR TITLE
improve(worktree): pnpm setup:worktree で検証コマンドが通る状態を一括整備

### DIFF
--- a/.claude/scripts/setup-worktree.sh
+++ b/.claude/scripts/setup-worktree.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# worktree 環境を pnpm install 後に検証コマンドが通る状態へ整える。
+#
+# 使い方:
+#   bash .claude/scripts/setup-worktree.sh
+#
+# 動作:
+#   1. 親リポの env ファイル (.env / .env.local / .env.*.local) をコピー
+#      → copy-worktree-env.sh を呼び出す
+#   2. 親リポの .vercel/ ディレクトリ全体を worktree にコピー
+#      → 親リポで vercel pull 済みの .env.preview.local / project.json をそのまま再利用
+#   3. apps/web で next typegen を実行
+#      → typed routes が生成する LayoutProps / PageProps の型を .next/types に出力
+#
+# 前提:
+#   - pnpm install が完了していること
+#   - 親リポで `npx vercel pull --yes --environment=preview` 済みであること
+#     (`.vercel/.env.preview.local` が親リポに存在する)
+#
+# 安全策:
+#   - 親リポと現在のworktreeが同一ディレクトリの場合は何もしない
+#   - .vercel をコピーする前に親リポに存在するかチェック
+
+set -euo pipefail
+
+current_root=$(git rev-parse --show-toplevel)
+common_dir=$(git rev-parse --git-common-dir)
+parent_root=$(cd "$(dirname "$common_dir")" && pwd)
+
+if [ "$current_root" = "$parent_root" ]; then
+  echo "現在のディレクトリは親リポジトリです。worktree でのみ実行してください。" >&2
+  exit 1
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+echo "==> 1/3 env ファイルをコピー"
+bash "${script_dir}/copy-worktree-env.sh"
+echo
+
+echo "==> 2/3 .vercel/ をコピー"
+parent_vercel="${parent_root}/.vercel"
+dest_vercel="${current_root}/.vercel"
+if [ ! -d "$parent_vercel" ]; then
+  echo "親リポに .vercel/ が無い。先に親リポで以下を実行:" >&2
+  echo "  npx vercel pull --yes --environment=preview" >&2
+  exit 1
+fi
+if [ ! -f "${parent_vercel}/.env.preview.local" ]; then
+  echo "親リポの .vercel/.env.preview.local が無い。親リポで以下を実行:" >&2
+  echo "  npx vercel pull --yes --environment=preview" >&2
+  exit 1
+fi
+mkdir -p "$dest_vercel"
+cp -R "${parent_vercel}/." "${dest_vercel}/"
+echo "copy: .vercel/ → ${dest_vercel}"
+echo
+
+echo "==> 3/3 next typegen で .next/types を生成"
+set -a
+# shellcheck disable=SC1091
+source "${dest_vercel}/.env.preview.local"
+set +a
+export APP_ENV="${APP_ENV:-development-worktree}"
+pnpm --filter @next-lift/web exec next typegen
+echo
+
+echo "完了: pnpm type-check / pnpm test を実行できる状態です。"

--- a/.claude/skills/worktree-tips/SKILL.md
+++ b/.claude/skills/worktree-tips/SKILL.md
@@ -57,7 +57,9 @@ description: worktree並列運用時に踏みやすい罠（DB / Git / node_modu
 | 罠 | 詳細 | 対策 |
 | --- | --- | --- |
 | 同一ファイル並行編集の後勝ち | 親と worktree が同じ論理ファイルを編集しても、worktree 間ではファイル分離。ただし同じブランチを別場所で進めていると merge 時に衝突 | worktree ごとに別ブランチを切る前提で運用 |
-| `.env.local` 未コピー | `git worktree add` は gitignored ファイルを持ち込まない | `pnpm worktree:copy-env` で明示コピー（→ #679） |
+| `.env.local` 未コピー | `git worktree add` は gitignored ファイルを持ち込まない | `pnpm setup:worktree` で env + `.vercel` + `next typegen` を一括整備（→ #823） |
+| `.next/types` 未生成で type-check 失敗 | `next.config.ts` の `typedRoutes: true` が出す `LayoutProps` / `PageProps` 型は `next dev` / `build` / `typegen` を一度走らせないと存在しない。`pnpm install` 直後の worktree で `pnpm type-check` が `TS2304` で落ちる | `pnpm setup:worktree` の `next typegen` ステップで生成（→ #823） |
+| `.vercel/.env.preview.local` 未取得で test / build 失敗 | `vercel pull` の結果が無いと `BETTER_AUTH_SECRET` 等の env 検証で落ちる。`copy-worktree-env.sh` は `.vercel` を走査対象外にしているため別途コピーが必要 | 親リポで `npx vercel pull --yes --environment=preview` 済みなら `pnpm setup:worktree` が `.vercel/` 全体をコピー（→ #823） |
 | stacked PR の base rebase 連鎖崩壊 | 3〜4 段以上に積むと base rebase で全段の force-push が必要になり破綻 | 実用上限は 3〜4 段。それ以上は親 PR を先にマージしてから次段を立てる |
 | 認証トークン共有 | `.env` に焼き付いたトークンが複数 worktree で共有されると revoke 連鎖が起きる | 短命トークン（→ #679）、または worktree ごとに分離した token を発行 |
 | Storybook / Chrome DevTools MCP の固定リソース取り合い | localhost:6006 や Chrome user-data-dir が衝突 | `STORYBOOK_PORT` で port を分ける、chrome-devtools は `--isolated=true`（→ #678）|

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Next.js / React Native (Expo) / Turso / Drizzle / Better Auth / React Aria Compo
 pnpm install
 ```
 
+### worktree でのセットアップ
+
+`git worktree add` 直後は env ファイル / `.vercel/` / Next.js の `.next/types` が無いため、`pnpm type-check` や `pnpm test` がローカルで落ちる。親リポでログイン済みであれば次のコマンドで一括整備できる。
+
+```sh
+# 親リポ側で一度だけ
+npx vercel pull --yes --environment=preview
+
+# worktree のルートで
+pnpm install
+pnpm setup:worktree
+```
+
+`pnpm setup:worktree` の中身は [worktree 運用ガイド](docs/development/worktree.md) を参照。
+
 ## 開発コマンド
 
 | コマンド | 説明 |

--- a/docs/development/worktree.md
+++ b/docs/development/worktree.md
@@ -8,23 +8,47 @@
 - 親リポジトリ（`/Users/.../next-lift`）と worktree（`.claude/worktrees/<name>/` など）は同一の `.git` を共有するが、作業ツリーは独立する
 - `node_modules`、`.env`、`.env.local`、`.next/`、`.turbo/` などはディレクトリごとに独立する
 
-## env ファイルの引き継ぎ
+## 検証コマンドが通る状態にする
 
-`.env` / `.env.local` / `.env.*.local` は gitignore 対象のため `git worktree add` では持ち込まれない。worktree 作成直後に親リポからコピーする。
+`git worktree add` 直後に `pnpm install` だけ走らせた状態では `pnpm type-check` / `pnpm test` が落ちる。理由は次の3点:
+
+1. `.env` / `.env.local` / `.env.*.local` は gitignore 対象のため worktree に持ち込まれない
+2. `.vercel/` も gitignore 対象で、`vercel pull` 済みの `.env.preview.local` が無い
+3. `next.config.ts` の `typedRoutes: true` が生成する `LayoutProps` / `PageProps` 型は `.next/types/**` に出力されるが、`next dev` / `next build` / `next typegen` を一度も走らせていない worktree には存在しない
+
+`pnpm setup:worktree` で上記3つを一括整備する。
 
 ```sh
-# worktree のルートで実行
-bash .claude/scripts/copy-worktree-env.sh
+# 親リポ側で一度だけ（VERCEL_TOKEN 不要、CLI ログイン済みなら通る）
+npx vercel pull --yes --environment=preview
+
+# worktree のルートで
+pnpm install
+pnpm setup:worktree
 ```
 
 スクリプトの動作:
 
-- 親リポの worktree ルート配下を再帰的に走査し、`.env` `.env.local` `.env.*.local` を抽出
-- 同じ相対パスで現在の worktree へコピー（`apps/web/.env` → `<worktree>/apps/web/.env` など）
-- 既存ファイルと内容が一致する場合はスキップ、差分があれば上書き
-- `node_modules` `.git` `.next` `.turbo` `dist` `build` `.vercel` は走査対象外
+1. `bash .claude/scripts/copy-worktree-env.sh` で env ファイルをコピー
+   - 親リポの worktree ルート配下を再帰的に走査し `.env` / `.env.local` / `.env.*.local` を抽出
+   - 同じ相対パスで現在の worktree へコピー（`apps/web/.env` → `<worktree>/apps/web/.env` など）
+   - 既存ファイルと内容が一致する場合はスキップ、差分があれば上書き
+   - `node_modules` `.git` `.next` `.turbo` `dist` `build` `.vercel` は走査対象外
+2. 親リポの `.vercel/` 全体を worktree にコピー
+   - `vercel pull` を再実行する代わりに、親リポでログイン済みの結果を再利用
+   - 並行作業中に親リポで `vercel pull` を再実行した場合は再度 `pnpm setup:worktree` を走らせる
+3. `pnpm --filter @next-lift/web exec next typegen` で `.next/types/**` を生成
+   - `APP_ENV` 未設定時は `development-worktree` をフォールバックで設定
 
 セキュリティ上の理由で、コピーは worktree から手動実行する明示的な仕組みにしている（自動 SessionStart hook で常時上書きはしない）。
+
+### env だけコピーしたいとき
+
+env だけ更新したい場合は単独で実行できる。
+
+```sh
+pnpm worktree:copy-env
+```
 
 ## Turso トークン管理
 
@@ -53,3 +77,4 @@ turso db tokens create <db-name> --expiration 24h
 
 - #678: Storybook ポート / chrome-devtools MCP プロファイル衝突対策
 - #680: worktree 並列作業の罠まとめ skill（予定）
+- #823: worktree で `pnpm install` 後に検証コマンドが通らない問題（`pnpm setup:worktree` で対応）

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"type-check": "turbo type-check",
 		"test": "turbo test",
 		"clean": "turbo clean",
-		"worktree:copy-env": "bash .claude/scripts/copy-worktree-env.sh"
+		"worktree:copy-env": "bash .claude/scripts/copy-worktree-env.sh",
+		"setup:worktree": "bash .claude/scripts/setup-worktree.sh"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.15",


### PR DESCRIPTION
# 概要

worktree を新規作成し `pnpm install` だけ走らせた状態では、env / `.vercel/` / `.next/types` が無いため `pnpm type-check` と `pnpm test` がローカルで落ちていた。親リポで `vercel pull` 済みであることを前提に、3つの整備を一括で行う `pnpm setup:worktree` スクリプトを追加する。

close #823

## この変更による影響

- 開発者（特に worktree 並列運用 / AI エージェント）向けの改善。アプリケーションの挙動には影響しない
- 新しい worktree 作成時の手順が `pnpm install && pnpm setup:worktree` の2ステップに整理される
- `pnpm worktree:copy-env` は単独でも利用可能なまま残す（env だけ更新したいケース用）

### `pnpm setup:worktree` の動作

1. `bash .claude/scripts/copy-worktree-env.sh` で env ファイル（`.env` / `.env.local` / `.env.*.local`）を親リポからコピー
2. 親リポの `.vercel/` 全体を worktree にコピー（`vercel pull` の結果を再利用、`VERCEL_TOKEN` 不要）
3. `pnpm --filter @next-lift/web exec next typegen` で `.next/types/**` を生成し `LayoutProps` / `PageProps` 型を解決
   - `APP_ENV` 未設定時は `development-worktree` をフォールバック

## CIでチェックできなかった項目

- 新規 worktree を作って `pnpm install && pnpm setup:worktree && pnpm type-check && pnpm test` が緑になることを手元で確認済み
- 親リポに `.vercel/` が無い場合のエラー分岐（`npx vercel pull` を促すメッセージ）は実機で確認済み

## 補足

- Issue #823 で提示された (3)「`packages/env` でテスト時 env の検証を緩める / デフォルト値」は影響範囲が大きく、本 PR では取り組まない。本スクリプトで env が揃うようになったため (3) の必要性は下がっている
- ドキュメントは `README.md` / `docs/development/worktree.md` / `.claude/skills/worktree-tips/SKILL.md` の3箇所を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)